### PR TITLE
Auto-derive stableId from serializer descriptor

### DIFF
--- a/sample/src/androidMain/kotlin/dev/mattramotar/meeseeks/sample/App.kt
+++ b/sample/src/androidMain/kotlin/dev/mattramotar/meeseeks/sample/App.kt
@@ -19,10 +19,9 @@ class App : Application(), Configuration.Provider {
             maxRetryCount(3)
             maxParallelTasks(5)
             allowExpedited()
-            register<SyncPayload>(SyncPayload.stableId) { SyncWorker(applicationContext) }
-            register<RefreshPayload>(RefreshPayload.stableId) { RefreshWorker(applicationContext) }
+            register<SyncPayload> { SyncWorker(applicationContext) }
+            register<RefreshPayload> { RefreshWorker(applicationContext) }
         }
-
     }
 
     override val workManagerConfiguration: Configuration by lazy {

--- a/sample/src/commonMain/kotlin/dev/mattramotar/meeseeks/sample/shared/RefreshPayload.kt
+++ b/sample/src/commonMain/kotlin/dev/mattramotar/meeseeks/sample/shared/RefreshPayload.kt
@@ -4,9 +4,4 @@ import dev.mattramotar.meeseeks.runtime.TaskPayload
 import kotlinx.serialization.Serializable
 
 @Serializable
-data object RefreshPayload : TaskPayload {
-    val stableId: String = V_1_0_0
-}
-
-// TODO: How do we handle migrations?
-private const val V_1_0_0 = "dev.mattramotar.meeseeks.sample.shared.RefreshPayload:1.0.0"
+data object RefreshPayload : TaskPayload

--- a/sample/src/commonMain/kotlin/dev/mattramotar/meeseeks/sample/shared/SyncPayload.kt
+++ b/sample/src/commonMain/kotlin/dev/mattramotar/meeseeks/sample/shared/SyncPayload.kt
@@ -4,10 +4,4 @@ import dev.mattramotar.meeseeks.runtime.TaskPayload
 import kotlinx.serialization.Serializable
 
 @Serializable
-data object SyncPayload : TaskPayload {
-
-    val stableId: String = V_1_0_0
-}
-
-// TODO: How do we handle migrations?
-private const val V_1_0_0 = "dev.mattramotar.meeseeks.sample.shared.SyncPayload:1.0.0"
+data object SyncPayload : TaskPayload


### PR DESCRIPTION
Fixes #29 

## Changes
- Replace `register<T>(stableId, factory)` with `register<T>(factory)`
- `stableId` is now derived from `serializer.descriptor.serialName`
- Remove manual `stableId` properties from sample payloads
- Update sample app to use new simplified registration API

## Customization
Users can customize the identifier using `@SerialName` annotation:

```kotlin
@Serializable
@SerialName("custom")
data class ExamplePayload(...) : TaskPayload
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces automatic derivation of `stableId` from `serializer.descriptor.serialName`, removing the need to pass or maintain manual identifiers.
> 
> - Change `register<T>(stableId, factory)` to `register<T>(factory)` and compute `stableId` via the serializer descriptor (customizable with `@SerialName`)
> - Enforce duplicate checks using the derived `stableId`
> - Update sample app to the new API and remove `stableId` properties from `SyncPayload` and `RefreshPayload`
> - Add serialization opt-in/imports to support descriptor access
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0dada6a7d79f914eab08485472245b50dc72e859. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->