### PR TITLE
Fix iOS BGTaskScheduler delay precision

### DIFF
--- a/runtime/src/nativeMain/kotlin/dev/mattramotar/meeseeks/runtime/BGTaskRunner.kt
+++ b/runtime/src/nativeMain/kotlin/dev/mattramotar/meeseeks/runtime/BGTaskRunner.kt
@@ -17,6 +17,7 @@ import platform.BackgroundTasks.BGTaskRequest
 import platform.Foundation.NSDate
 import platform.Foundation.dateWithTimeIntervalSinceNow
 import kotlin.time.Duration
+import kotlin.time.DurationUnit
 
 
 internal class BGTaskRunner(
@@ -151,7 +152,7 @@ internal class BGTaskRunner(
             BGAppRefreshTaskRequest(identifier)
         }
 
-        val earliestSeconds = delay.inWholeSeconds.toDouble()
+        val earliestSeconds = delay.toDouble(DurationUnit.SECONDS)
         if (earliestSeconds > 0.0) {
             bgTaskRequest.earliestBeginDate = NSDate.dateWithTimeIntervalSinceNow(earliestSeconds)
         }

--- a/runtime/src/nativeMain/kotlin/dev/mattramotar/meeseeks/runtime/internal/NativeTaskScheduler.kt
+++ b/runtime/src/nativeMain/kotlin/dev/mattramotar/meeseeks/runtime/internal/NativeTaskScheduler.kt
@@ -24,6 +24,7 @@ import platform.Foundation.NSDate
 import platform.Foundation.NSError
 import platform.Foundation.NSLog
 import platform.Foundation.dateWithTimeIntervalSinceNow
+import kotlin.time.DurationUnit
 
 @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
 internal class NativeTaskScheduler(
@@ -140,8 +141,8 @@ internal class NativeTaskScheduler(
         }
 
         val earliestDelaySeconds = when (schedule) {
-            is TaskSchedule.OneTime -> schedule.initialDelay.inWholeSeconds.toDouble()
-            is TaskSchedule.Periodic -> schedule.initialDelay.inWholeSeconds.toDouble()
+            is TaskSchedule.OneTime -> schedule.initialDelay.toDouble(DurationUnit.SECONDS)
+            is TaskSchedule.Periodic -> schedule.initialDelay.toDouble(DurationUnit.SECONDS)
         }
 
         if (earliestDelaySeconds > 0) {


### PR DESCRIPTION
## Summary
- preserve fractional seconds for BGTaskScheduler earliestBeginDate
- avoid truncation when scheduling initial delays and resubmits

## Testing
- ./gradlew :runtime:compileKotlinIosSimulatorArm64

Fixes #30

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves iOS BGTaskScheduler timing precision by preserving fractional-second delays when setting `earliestBeginDate`.
> 
> - Switches from `Duration.inWholeSeconds.toDouble()` to `Duration.toDouble(DurationUnit.SECONDS)` in `BGTaskRunner` and `NativeTaskScheduler` to avoid truncating sub-second delays for both resubmits and initial schedules
> - Adds necessary `DurationUnit` imports
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb696be38361a6bd6c86e5450d2aa5f1958e2d7a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->