### PR TITLE
Add opt-in payload encryption

### DIFF
--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -33,6 +33,12 @@ kotlin {
             }
         }
 
+        commonTest {
+            dependencies {
+                implementation(libs.kotlin.test)
+            }
+        }
+
         androidMain {
             dependencies {
                 api(libs.androidx.work.runtime.ktx)

--- a/runtime/src/commonMain/kotlin/dev/mattramotar/meeseeks/runtime/BGTaskManagerConfig.kt
+++ b/runtime/src/commonMain/kotlin/dev/mattramotar/meeseeks/runtime/BGTaskManagerConfig.kt
@@ -12,6 +12,7 @@ import dev.mattramotar.meeseeks.runtime.internal.TaskExecutor
  * @property orphanedTaskWatchdogInterval Interval for the orphaned task watchdog to check for tasks that are enqueued in the database
  *      but not scheduled with the platform. This can happen if the process dies after [TaskExecutor] updates the DB but before the
  *      platform worker schedules the next execution. Set to [Duration.ZERO] to disable the watchdog.
+ * @property payloadCipher Optional cipher used to encrypt/decrypt task payloads stored in the database.
  */
 data class BGTaskManagerConfig(
     val maxParallelTasks: Int = 2,
@@ -19,6 +20,6 @@ data class BGTaskManagerConfig(
     val maxRetryCount: Int = 3,
     val minBackoff: Duration = 10.seconds,
     val telemetry: Telemetry? = null,
+    val payloadCipher: PayloadCipher? = null,
     val orphanedTaskWatchdogInterval: Duration = 5.minutes
 )
-

--- a/runtime/src/commonMain/kotlin/dev/mattramotar/meeseeks/runtime/ConfigurationScope.kt
+++ b/runtime/src/commonMain/kotlin/dev/mattramotar/meeseeks/runtime/ConfigurationScope.kt
@@ -51,6 +51,13 @@ class ConfigurationScope internal constructor(private val appContext: AppContext
         config = config.copy(telemetry = Telemetry(handler))
     }
 
+    /**
+     * Enables encryption for task payloads stored in the database.
+     */
+    fun payloadCipher(cipher: PayloadCipher): ConfigurationScope = apply {
+        config = config.copy(payloadCipher = cipher)
+    }
+
 
     /**
      * Registers a [Worker] for the given [TaskPayload] type.
@@ -90,7 +97,7 @@ class ConfigurationScope internal constructor(private val appContext: AppContext
     }
 
     internal fun build(): BGTaskManager {
-        val registry = WorkerRegistry(getRegistrations(), json)
+        val registry = WorkerRegistry(getRegistrations(), json, config.payloadCipher)
         val database = createDatabaseInstance(appContext, json)
         return createBGTaskManager(appContext, database, registry, json, config)
     }

--- a/runtime/src/commonMain/kotlin/dev/mattramotar/meeseeks/runtime/PayloadCipher.kt
+++ b/runtime/src/commonMain/kotlin/dev/mattramotar/meeseeks/runtime/PayloadCipher.kt
@@ -1,0 +1,12 @@
+package dev.mattramotar.meeseeks.runtime
+
+/**
+ * Encrypts and decrypts task payload data before it is stored in the database.
+ *
+ * Implementations must be deterministic and reversible across app launches.
+ * Returned ciphertext must be safe to store as TEXT (e.g., Base64-encode binary output).
+ */
+interface PayloadCipher {
+    fun encrypt(plaintext: String): String
+    fun decrypt(ciphertext: String): String
+}

--- a/runtime/src/commonMain/sqldelight/dev/mattramotar/meeseeks/runtime/db/TaskSpec.sq
+++ b/runtime/src/commonMain/sqldelight/dev/mattramotar/meeseeks/runtime/db/TaskSpec.sq
@@ -14,7 +14,7 @@ CREATE TABLE taskSpec (
 
     -- Payload
     payload_type_id TEXT NOT NULL,
-    payload_data TEXT NOT NULL, -- Serialization is handled externally by WorkerRegistry
+    payload_data TEXT NOT NULL, -- Serialized payload (encrypted if PayloadCipher is configured)
 
     -- Priority
     priority INTEGER NOT NULL, -- Normalized integer (Low=10, Medium=50, High=100)

--- a/runtime/src/commonTest/kotlin/dev/mattramotar/meeseeks/runtime/internal/WorkerRegistryPayloadCipherTest.kt
+++ b/runtime/src/commonTest/kotlin/dev/mattramotar/meeseeks/runtime/internal/WorkerRegistryPayloadCipherTest.kt
@@ -1,0 +1,75 @@
+package dev.mattramotar.meeseeks.runtime.internal
+
+import dev.mattramotar.meeseeks.runtime.PayloadCipher
+import dev.mattramotar.meeseeks.runtime.TaskPayload
+import dev.mattramotar.meeseeks.runtime.WorkerFactory
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalSerializationApi::class)
+class WorkerRegistryPayloadCipherTest {
+
+    @Serializable
+    private data class TestPayload(val value: String) : TaskPayload
+
+    private class ReversingCipher : PayloadCipher {
+        override fun encrypt(plaintext: String): String = plaintext.reversed()
+        override fun decrypt(ciphertext: String): String = ciphertext.reversed()
+    }
+
+    private val json = Json
+
+    private fun registry(cipher: PayloadCipher?): WorkerRegistry {
+        val serializer = TestPayload.serializer()
+        val registration = WorkerRegistration(
+            type = TestPayload::class,
+            typeId = serializer.descriptor.serialName,
+            serializer = serializer,
+            factory = WorkerFactory<TestPayload> { error("unused") }
+        )
+
+        return WorkerRegistry(
+            registrations = mapOf(TestPayload::class to registration),
+            json = json,
+            payloadCipher = cipher
+        )
+    }
+
+    @Test
+    fun encryptsAndDecryptsPayloadWhenCipherConfigured() {
+        val payload = TestPayload("secret")
+        val registry = registry(ReversingCipher())
+
+        val serialized = registry.serializePayload(payload)
+
+        assertTrue(serialized.data.startsWith("enc:v1:"))
+        val roundTrip = registry.deserializePayload(serialized.typeId, serialized.data)
+        assertEquals(payload, roundTrip)
+    }
+
+    @Test
+    fun readsPlaintextPayloadWhenCipherConfigured() {
+        val payload = TestPayload("plaintext")
+        val registry = registry(ReversingCipher())
+        val plainData = json.encodeToString(TestPayload.serializer(), payload)
+
+        val roundTrip = registry.deserializePayload(TestPayload.serializer().descriptor.serialName, plainData)
+
+        assertEquals(payload, roundTrip)
+    }
+
+    @Test
+    fun throwsWhenEncryptedPayloadWithoutCipher() {
+        val registry = registry(null)
+
+        assertFailsWith<IllegalStateException> {
+            registry.deserializePayload(TestPayload.serializer().descriptor.serialName, "enc:v1:ciphertext")
+        }
+    }
+}


### PR DESCRIPTION
Fixes #31

## Summary
- add PayloadCipher API and configuration hook for opt-in payload encryption
- encrypt/decrypt payload_data with an enc:v1 prefix and plaintext fallback
- add unit tests for encrypted and plaintext payload handling

## Testing
- ./gradlew :runtime:jvmTest


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces opt-in encryption for stored task payloads and wires it through configuration and serialization.
> 
> - Adds `PayloadCipher` API and `payloadCipher` in `BGTaskManagerConfig` with `ConfigurationScope.payloadCipher(...)`
> - Updates `WorkerRegistry` to encrypt on serialize and decrypt on deserialize using `enc:v1:` prefix; plaintext fallback; throws if encrypted data without configured cipher
> - Clarifies `payload_data` comment in `TaskSpec.sq`
> - Adds `commonTest` source set and unit tests for encrypted/plaintext payload handling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3f8487cbcf778179a51c503fa909fbf55f6bdb2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->