### PR TITLE
Ensure WorkManager input data only stores task_id

### DIFF
--- a/runtime/src/androidMain/kotlin/dev/mattramotar/meeseeks/runtime/internal/WorkRequestFactory.android.kt
+++ b/runtime/src/androidMain/kotlin/dev/mattramotar/meeseeks/runtime/internal/WorkRequestFactory.android.kt
@@ -2,10 +2,10 @@ package dev.mattramotar.meeseeks.runtime.internal
 
 import android.os.Build
 import androidx.work.Constraints
+import androidx.work.Data
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.OutOfQuotaPolicy
-import androidx.work.workDataOf
 import dev.mattramotar.meeseeks.runtime.BGTaskManagerConfig
 import dev.mattramotar.meeseeks.runtime.TaskRequest
 import dev.mattramotar.meeseeks.runtime.TaskSchedule
@@ -33,7 +33,7 @@ internal actual class WorkRequestFactory(
     ): WorkRequest {
         val constraints = buildConstraints(taskRequest)
 
-        val inputData = workDataOf(KEY_TASK_ID to taskId)
+        val inputData = buildInputData(taskId)
 
         val builder = OneTimeWorkRequestBuilder<BGTaskCoroutineWorker>()
             .setConstraints(constraints)
@@ -70,6 +70,13 @@ internal actual class WorkRequestFactory(
             builder.setRequiresBatteryNotLow(true)
         }
         return builder.build()
+    }
+
+    private fun buildInputData(taskId: String): Data {
+        // WorkManager Data only supports primitives; payload is stored in the database.
+        return Data.Builder()
+            .putString(KEY_TASK_ID, taskId)
+            .build()
     }
 
     actual companion object {

--- a/runtime/src/androidUnitTest/kotlin/dev/mattramotar/meeseeks/runtime/internal/WorkRequestFactoryAndroidTest.kt
+++ b/runtime/src/androidUnitTest/kotlin/dev/mattramotar/meeseeks/runtime/internal/WorkRequestFactoryAndroidTest.kt
@@ -1,0 +1,24 @@
+package dev.mattramotar.meeseeks.runtime.internal
+
+import dev.mattramotar.meeseeks.runtime.BGTaskManagerConfig
+import dev.mattramotar.meeseeks.runtime.TaskPayload
+import dev.mattramotar.meeseeks.runtime.TaskRequest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class WorkRequestFactoryAndroidTest {
+    private object TestPayload : TaskPayload
+
+    @Test
+    fun createWorkRequest_storesOnlyTaskIdInInputData() {
+        val taskId = "task-id-123"
+        val request = TaskRequest.oneTime(TestPayload)
+        val factory = WorkRequestFactory()
+
+        val workRequest = factory.createWorkRequest(taskId, request, BGTaskManagerConfig())
+        val inputData = workRequest.delegate.workSpec.input
+
+        assertEquals(setOf(WorkRequestFactory.KEY_TASK_ID), inputData.keyValueMap.keys)
+        assertEquals(taskId, inputData.getString(WorkRequestFactory.KEY_TASK_ID))
+    }
+}


### PR DESCRIPTION
## Summary
- centralize WorkManager input data creation to keep payloads out of Data
- add an Android unit test to guard the input data keys

## Testing
- ./gradlew :runtime:testDebugUnitTest

Fixes #9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures WorkManager input `Data` contains only `task_id`, preventing payloads from being placed in `Data`.
> 
> - Replace `workDataOf` usage with centralized `buildInputData` using `Data.Builder` to write only `KEY_TASK_ID`
> - Add `WorkRequestFactoryAndroidTest` validating that input `Data` has exactly `task_id` and correct value
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7a766af16a5257efc77399d0d2d7adc37b90b3e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->