### PR TITLE
Prevent iOS crash when logging TaskResult.Type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This project follows semantic versioning.
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-02-20
+
+### Fixed
+
+- Resolved iOS crash when logging task results by replacing `TaskResult.Type` serializer lookup in `TaskResultAdapter` with string-based encoding/decoding and compatibility handling for both JSON-quoted and plain stored values (issue #64).
+
 ## [1.0.0] - 2026-02-17
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.configuration-cache=false
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=1g
 android.useAndroidX=true
 GROUP=dev.mattramotar.meeseeks
-VERSION_NAME=1.0.0
+VERSION_NAME=1.0.1
 POM_PACKAGING=pom
 POM_DESCRIPTION=A Kotlin Multiplatform library for scheduling and managing background tasks
 POM_URL=https://github.com/matt-ramotar/meeseeks

--- a/runtime/src/commonMain/kotlin/dev/mattramotar/meeseeks/runtime/internal/db/adapters/TaskResultAdapter.kt
+++ b/runtime/src/commonMain/kotlin/dev/mattramotar/meeseeks/runtime/internal/db/adapters/TaskResultAdapter.kt
@@ -2,6 +2,7 @@ package dev.mattramotar.meeseeks.runtime.internal.db.adapters
 
 import app.cash.sqldelight.ColumnAdapter
 import dev.mattramotar.meeseeks.runtime.TaskResult
+import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
@@ -9,11 +10,22 @@ internal class TaskResultAdapter(
     private val json: Json
 ) : ColumnAdapter<TaskResult.Type, String> {
     override fun decode(databaseValue: String): TaskResult.Type {
-        return json.decodeFromString(databaseValue)
+        val decodedValue = try {
+            json.decodeFromString<String>(databaseValue)
+        } catch (_: IllegalArgumentException) {
+            // Fallback for legacy enum values stored without JSON quotes.
+            databaseValue
+        }
+
+        return try {
+            TaskResult.Type.valueOf(decodedValue)
+        } catch (error: IllegalArgumentException) {
+            throw IllegalArgumentException("Unknown TaskResult.Type value: $databaseValue", error)
+        }
     }
 
     override fun encode(value: TaskResult.Type): String {
-        return json.encodeToString(value)
+        return json.encodeToString(value.name)
     }
 
 }

--- a/runtime/src/commonTest/kotlin/dev/mattramotar/meeseeks/runtime/internal/db/adapters/TaskResultAdapterTest.kt
+++ b/runtime/src/commonTest/kotlin/dev/mattramotar/meeseeks/runtime/internal/db/adapters/TaskResultAdapterTest.kt
@@ -1,0 +1,49 @@
+package dev.mattramotar.meeseeks.runtime.internal.db.adapters
+
+import dev.mattramotar.meeseeks.runtime.TaskResult
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class TaskResultAdapterTest {
+
+    private val adapter = TaskResultAdapter(Json)
+
+    @Test
+    fun roundTripEncodeDecodeSupportsAllResultTypes() {
+        TaskResult.Type.entries.forEach { type ->
+            val encoded = adapter.encode(type)
+            val decoded = adapter.decode(encoded)
+
+            assertEquals(type, decoded)
+        }
+    }
+
+    @Test
+    fun decodeSupportsJsonQuotedLegacyValue() {
+        val serializedLegacyValue = Json.encodeToString(TaskResult.Type.Success.name)
+
+        val decoded = adapter.decode(serializedLegacyValue)
+
+        assertEquals(TaskResult.Type.Success, decoded)
+    }
+
+    @Test
+    fun decodeSupportsPlainTokenFallback() {
+        val decoded = adapter.decode(TaskResult.Type.Success.name)
+
+        assertEquals(TaskResult.Type.Success, decoded)
+    }
+
+    @Test
+    fun decodeFailsClearlyForUnknownToken() {
+        val error = assertFailsWith<IllegalArgumentException> {
+            adapter.decode("UnknownValue")
+        }
+
+        assertTrue(error.message?.contains("Unknown TaskResult.Type value: UnknownValue") == true)
+    }
+}


### PR DESCRIPTION
Fixes #64 

- Refactored `TaskResultAdapter` to serialize `TaskResult.Type` as a string name instead of relying on enum serializer discovery on Kotlin/Native
- Added decode compatibility for both JSON-quoted values and plain tokens
- Added regression tests for round-trip encoding/decoding, legacy compatibility, and invalid-value failure behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to DB serialization plus new tests; main risk is potential incompatibility if any stored values differ from enum names, but legacy formats are explicitly handled.
> 
> **Overview**
> Prevents an iOS/KotlinNative crash when persisting/logging `TaskResult.Type` by changing `TaskResultAdapter` to encode enum values as their `.name` (JSON string) and decode via `valueOf` rather than relying on enum serializer lookup.
> 
> Decoding is made backward compatible with both JSON-quoted strings and legacy unquoted tokens, with a clearer error for unknown values. Adds unit tests covering round-trip behavior, legacy formats, and invalid tokens, and bumps version/release notes to `1.0.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7bd898997582160a661fb91ed39ef3013fd68a8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->