### PR TITLE
migrate from `kotlinx.datetime.Clock` to `kotlin.time.Clock`

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,8 +4,7 @@ compose-bom = "2024.12.01"
 compose-lint-checks = "1.2.0"
 desugar = "2.1.3"
 jetbrains-compose = "1.7.0"
-kotlin = "2.1.0"
-kotlinx-datetime = "0.6.2"
+kotlin = "2.3.10"
 kotlinx-serialization = "1.7.3"
 kotlinx-coroutines = "1.9.0"
 kover = "0.9.7"
@@ -36,7 +35,6 @@ androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version
 android-driver = { module = "app.cash.sqldelight:android-driver", version.ref = "sqldelight" }
 coroutines-extensions = { module = "app.cash.sqldelight:coroutines-extensions", version.ref = "sqldelight" }
 jdbc-driver = { module = "app.cash.sqldelight:jdbc-driver", version.ref = "sqldelight" }
-kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 native-driver = { module = "app.cash.sqldelight:native-driver", version.ref = "sqldelight" }
 quartz = { module = "org.quartz-scheduler:quartz", version.ref = "quartz" }
 sqlite-driver = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqldelight" }

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -31,7 +31,6 @@ kotlin {
                 api(libs.kotlinx.serialization.core)
                 api(libs.kotlinx.serialization.json)
                 implementation(libs.kotlin.reflect)
-                implementation(libs.kotlinx.datetime)
                 implementation(libs.coroutines.extensions)
             }
         }

--- a/runtime/src/commonMain/kotlin/dev/mattramotar/meeseeks/runtime/internal/Timestamp.kt
+++ b/runtime/src/commonMain/kotlin/dev/mattramotar/meeseeks/runtime/internal/Timestamp.kt
@@ -1,6 +1,6 @@
 package dev.mattramotar.meeseeks.runtime.internal
 
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 internal object Timestamp {
     fun now(): Long = Clock.System.now().toEpochMilliseconds()


### PR DESCRIPTION
Fixes #66

Migrates [Timestamp.kt ](https://github.com/matt-ramotar/meeseeks/blob/main/runtime/src/commonMain/kotlin/dev/mattramotar/meeseeks/runtime/internal/Timestamp.kt)from `kotlinx.datetime.Clock` to `kotlin.time.Clock` (Kotlin stdlib) and removes the kotlinx-datetime dependency entirely.