### PR TITLE
MEESEEK-55: Document completion replay startup pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,25 @@ val stream = manager.observeStatus(taskId)
 oneTime.cancel()
 ```
 
+### 5) Replay missed completions on startup
+
+```kotlin
+val missedEvents = manager.replayTerminalEvents(lastHandledEventId)
+missedEvents.forEach { event ->
+    when (event.outcome) {
+        TaskEventOutcome.Success -> showCompleted(event.taskId)
+        TaskEventOutcome.Failure -> showFailed(event.taskId)
+        TaskEventOutcome.Cancelled -> showCancelled(event.taskId)
+    }
+}
+```
+
 ## Platform Setup
 
 - Android guide: `docs/platforms/android.md`
 - iOS guide: `docs/platforms/ios.md`
 - JS guide: `docs/platforms/js.md`
+- Completion replay: `docs/completion-replay.md`
 - Capability matrix: `docs/capabilities.md`
 - Troubleshooting: `docs/troubleshooting.md`
 - Migration notes: `docs/migration-0x-to-1x.md`

--- a/docs/completion-replay.md
+++ b/docs/completion-replay.md
@@ -1,0 +1,85 @@
+# Completion Replay
+
+Meeseeks task status observation is live. `observeStatus(taskId)` reports updates while the collector is active, but it does not buffer transitions that happen while the app process, UI, or subscription is gone.
+
+Terminal event replay is durable. `replayTerminalEvents(sinceEventId)` and `getTaskEvents(taskId)` read persisted task log rows, so startup code can recover completions that happened while no UI observer was active.
+
+## Startup replay pattern
+
+Store the highest event id that your app has already handled. On startup, initialize Meeseeks, replay newer terminal events, update UI or local app state, then persist the newest event id.
+
+```kotlin
+class CompletionReplayStore {
+    fun lastHandledEventId(): Long = TODO("Read from app settings or local storage")
+    fun saveLastHandledEventId(id: Long) {
+        TODO("Write to app settings or local storage")
+    }
+}
+
+fun replayMissedCompletions(
+    manager: BGTaskManager,
+    store: CompletionReplayStore,
+    render: (TaskEvent) -> Unit,
+) {
+    val events = manager.replayTerminalEvents(store.lastHandledEventId())
+    events.forEach { event ->
+        render(event)
+    }
+    events.lastOrNull()?.let { event ->
+        store.saveLastHandledEventId(event.id)
+    }
+}
+```
+
+Use task-scoped replay when a screen knows the task it cares about:
+
+```kotlin
+fun recoverTaskScreen(
+    manager: BGTaskManager,
+    taskId: TaskId,
+    render: (TaskEvent) -> Unit,
+) {
+    manager.getTaskEvents(taskId).forEach(render)
+}
+```
+
+## Outcome handling
+
+Replay events use `TaskEventOutcome`:
+
+- `Success`: a one-time task completed successfully.
+- `Failure`: a task reached permanent failure, including retry exhaustion.
+- `Cancelled`: the task was explicitly cancelled.
+
+Periodic successful runs are not terminal. They schedule the next activation and are not returned by terminal replay. A periodic task is replayed only when it reaches `Failure` or `Cancelled`.
+
+## Live observation versus durable replay
+
+Use live status APIs for active UI:
+
+```kotlin
+val stream = manager.observeStatus(taskId)
+```
+
+Use durable replay for startup recovery:
+
+```kotlin
+val missedEvents = manager.replayTerminalEvents(lastHandledEventId)
+```
+
+`getTaskStatus(taskId)` returns the current persisted status. Event replay returns ordered terminal events with ids that can be used as a durable cursor.
+
+## Platform caveats
+
+- Android wakeups are delegated to WorkManager. Replay recovers the outcome after the app next initializes Meeseeks.
+- JVM and JS can replay outcomes from Meeseeks persistence after the manager is recreated.
+- iOS background task wakeups are OS-managed and best effort. Replay does not guarantee an immediate background wakeup; it lets the app recover missed terminal outcomes when the app next starts or receives a background execution window.
+
+## Verification steps
+
+1. Schedule a one-time task and store the current replay cursor.
+2. Stop collecting `observeStatus(taskId)` or close the UI that owns the collector.
+3. Let the worker finish with `Success`, `Failure`, or `Cancelled`.
+4. Recreate the app manager or restart the app.
+5. Call `replayTerminalEvents(lastHandledEventId)` or `getTaskEvents(taskId)`.
+6. Confirm the recovered event outcome matches the terminal task state and persist the newest event id.

--- a/docs/completion-replay.md
+++ b/docs/completion-replay.md
@@ -4,6 +4,8 @@ Meeseeks task status observation is live. `observeStatus(taskId)` reports update
 
 Terminal event replay is durable. `replayTerminalEvents(sinceEventId)` and `getTaskEvents(taskId)` read persisted task log rows, so startup code can recover completions that happened while no UI observer was active.
 
+Replay events are immutable facts recorded when the outcome happens; later schedule changes never reclassify past events.
+
 ## Startup replay pattern
 
 Store the highest event id that your app has already handled. On startup, initialize Meeseeks, replay newer terminal events, update UI or local app state, then persist the newest event id.
@@ -31,6 +33,8 @@ fun replayMissedCompletions(
 }
 ```
 
+Delivery is at-least-once. If the app dies after `render` but before `saveLastHandledEventId` persists the new cursor, the same events are delivered again on the next replay, so render handlers must be idempotent.
+
 Use task-scoped replay when a screen knows the task it cares about:
 
 ```kotlin
@@ -52,6 +56,8 @@ Replay events use `TaskEventOutcome`:
 - `Cancelled`: the task was explicitly cancelled.
 
 Periodic successful runs are not terminal. They schedule the next activation and are not returned by terminal replay. A periodic task is replayed only when it reaches `Failure` or `Cancelled`.
+
+Cancelling a task that already finished is a no-op: the task keeps its original outcome and no `Cancelled` event is recorded. One edge case is worth knowing: cancelling a task while an attempt is already running cannot stop that attempt, so the attempt can still finish and record a second terminal event after the `Cancelled` one.
 
 ## Live observation versus durable replay
 

--- a/sample/src/commonMain/kotlin/dev/mattramotar/meeseeks/sample/SyncTaskManager.kt
+++ b/sample/src/commonMain/kotlin/dev/mattramotar/meeseeks/sample/SyncTaskManager.kt
@@ -1,6 +1,7 @@
 package dev.mattramotar.meeseeks.sample
 
 import dev.mattramotar.meeseeks.runtime.BGTaskManager
+import dev.mattramotar.meeseeks.runtime.TaskEvent
 import dev.mattramotar.meeseeks.runtime.TaskHandle
 import dev.mattramotar.meeseeks.runtime.TaskId
 import dev.mattramotar.meeseeks.runtime.TaskRequest
@@ -8,6 +9,7 @@ import dev.mattramotar.meeseeks.runtime.TaskStatus
 import dev.mattramotar.meeseeks.runtime.dsl.TaskRequestConfigurationScope
 import dev.mattramotar.meeseeks.runtime.oneTime
 import dev.mattramotar.meeseeks.runtime.periodic
+import dev.mattramotar.meeseeks.runtime.replayTerminalEvents
 import dev.mattramotar.meeseeks.sample.shared.SyncPayload
 import dev.mattramotar.meeseeks.sample.shared.Update
 import kotlinx.coroutines.flow.Flow
@@ -37,6 +39,15 @@ class SyncTaskManager(
 
     fun observeStatus(taskId: TaskId): Flow<TaskStatus?> =
         bgTaskManager.observeStatus(taskId)
+
+    fun replayMissedCompletions(
+        lastHandledEventId: Long,
+        handleEvent: (TaskEvent) -> Unit
+    ): Long {
+        val events = bgTaskManager.replayTerminalEvents(lastHandledEventId)
+        events.forEach(handleEvent)
+        return events.lastOrNull()?.id ?: lastHandledEventId
+    }
 
     fun reschedule(taskId: TaskId) {
         val updates = listOf(Update("new token"))


### PR DESCRIPTION
## Summary
Adds the app-death completion replay docs and sample helper for the durable replay API introduced in #73.

- Adds `docs/completion-replay.md` with startup cursor replay, task-scoped replay, outcome handling, platform caveats, and verification steps.
- Documents the delivery contract: replay events are immutable write-time facts, delivery is at-least-once (handlers must be idempotent), and cancelling an already-finished task is a no-op.
- Links completion replay from the README quickstart and platform setup list.
- Adds `SyncTaskManager.replayMissedCompletions` as a copyable common sample helper.

## What stayed untouched
- No checkpoint APIs are introduced here.
- Runtime API behavior is unchanged in this stacked docs/sample PR.

## Test plan
- [x] `./gradlew :sample:compileKotlinJvm :sample:compileKotlinJs preflight :runtime:jvmTest`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)