### PR TITLE
MEESEEK-57: Implement checkpoint persistence for resumable workers

### DIFF
--- a/runtime/api/android/runtime.api
+++ b/runtime/api/android/runtime.api
@@ -52,10 +52,10 @@ public abstract interface class dev/mattramotar/meeseeks/runtime/CheckpointStore
 	public abstract fun clear (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun clear$default (Ldev/mattramotar/meeseeks/runtime/CheckpointStore;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public abstract fun clearAll (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun read (Ljava/lang/String;Lkotlinx/serialization/KSerializer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun read$default (Ldev/mattramotar/meeseeks/runtime/CheckpointStore;Ljava/lang/String;Lkotlinx/serialization/KSerializer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public abstract fun write (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/KSerializer;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun write$default (Ldev/mattramotar/meeseeks/runtime/CheckpointStore;Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/KSerializer;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun read (Lkotlinx/serialization/KSerializer;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun read$default (Ldev/mattramotar/meeseeks/runtime/CheckpointStore;Lkotlinx/serialization/KSerializer;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun write (Ljava/lang/Object;Lkotlinx/serialization/KSerializer;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun write$default (Ldev/mattramotar/meeseeks/runtime/CheckpointStore;Ljava/lang/Object;Lkotlinx/serialization/KSerializer;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class dev/mattramotar/meeseeks/runtime/CheckpointStore$Companion {
@@ -64,12 +64,14 @@ public final class dev/mattramotar/meeseeks/runtime/CheckpointStore$Companion {
 
 public final class dev/mattramotar/meeseeks/runtime/CheckpointStore$DefaultImpls {
 	public static synthetic fun clear$default (Ldev/mattramotar/meeseeks/runtime/CheckpointStore;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun read$default (Ldev/mattramotar/meeseeks/runtime/CheckpointStore;Ljava/lang/String;Lkotlinx/serialization/KSerializer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun write$default (Ldev/mattramotar/meeseeks/runtime/CheckpointStore;Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/KSerializer;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun read$default (Ldev/mattramotar/meeseeks/runtime/CheckpointStore;Lkotlinx/serialization/KSerializer;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun write$default (Ldev/mattramotar/meeseeks/runtime/CheckpointStore;Ljava/lang/Object;Lkotlinx/serialization/KSerializer;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
-public abstract interface class dev/mattramotar/meeseeks/runtime/CheckpointedWorker {
+public abstract class dev/mattramotar/meeseeks/runtime/CheckpointedWorker : dev/mattramotar/meeseeks/runtime/Worker {
+	public fun <init> (Landroid/content/Context;)V
 	public abstract fun run (Ldev/mattramotar/meeseeks/runtime/TaskPayload;Ldev/mattramotar/meeseeks/runtime/RuntimeContext;Ldev/mattramotar/meeseeks/runtime/CheckpointStore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun run (Ldev/mattramotar/meeseeks/runtime/TaskPayload;Ldev/mattramotar/meeseeks/runtime/RuntimeContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class dev/mattramotar/meeseeks/runtime/ConfigurationScope {
@@ -580,25 +582,23 @@ public final class dev/mattramotar/meeseeks/runtime/db/SelectEarliestNextRunTime
 }
 
 public final class dev/mattramotar/meeseeks/runtime/db/TaskCheckpointEntity {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;JJ)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JJ)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()J
-	public final fun component7 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()J
 	public final fun component8 ()J
-	public final fun component9 ()J
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;JJ)Ldev/mattramotar/meeseeks/runtime/db/TaskCheckpointEntity;
-	public static synthetic fun copy$default (Ldev/mattramotar/meeseeks/runtime/db/TaskCheckpointEntity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;JJILjava/lang/Object;)Ldev/mattramotar/meeseeks/runtime/db/TaskCheckpointEntity;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JJ)Ldev/mattramotar/meeseeks/runtime/db/TaskCheckpointEntity;
+	public static synthetic fun copy$default (Ldev/mattramotar/meeseeks/runtime/db/TaskCheckpointEntity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JJILjava/lang/Object;)Ldev/mattramotar/meeseeks/runtime/db/TaskCheckpointEntity;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCheckpoint_key ()Ljava/lang/String;
 	public final fun getCheckpoint_type_id ()Ljava/lang/String;
 	public final fun getCreated_at_ms ()J
 	public final fun getData_ ()Ljava/lang/String;
 	public final fun getPayload_type_id ()Ljava/lang/String;
-	public final fun getSchema_version ()J
 	public final fun getTask_id ()Ljava/lang/String;
 	public final fun getUpdated_at_ms ()J
 	public final fun getWorker_type_id ()Ljava/lang/String;
@@ -611,10 +611,10 @@ public final class dev/mattramotar/meeseeks/runtime/db/TaskCheckpointQueries : a
 	public final fun countCheckpointsForTask (Ljava/lang/String;)Lapp/cash/sqldelight/Query;
 	public final fun deleteAllCheckpointsForTask (Ljava/lang/String;)V
 	public final fun deleteCheckpoint (Ljava/lang/String;Ljava/lang/String;)V
-	public final fun insertCheckpoint (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;JJ)V
+	public final fun insertCheckpoint (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JJ)V
 	public final fun selectCheckpoint (Ljava/lang/String;Ljava/lang/String;)Lapp/cash/sqldelight/Query;
-	public final fun selectCheckpoint (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function9;)Lapp/cash/sqldelight/Query;
-	public final fun updateCheckpoint (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;JLjava/lang/String;Ljava/lang/String;)V
+	public final fun selectCheckpoint (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function8;)Lapp/cash/sqldelight/Query;
+	public final fun updateCheckpoint (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;)V
 }
 
 public final class dev/mattramotar/meeseeks/runtime/db/TaskLogEntity {

--- a/runtime/api/android/runtime.api
+++ b/runtime/api/android/runtime.api
@@ -37,6 +37,41 @@ public final class dev/mattramotar/meeseeks/runtime/BGTaskManagerKt {
 	public static final fun schedule (Ldev/mattramotar/meeseeks/runtime/BGTaskManager;Ldev/mattramotar/meeseeks/runtime/TaskRequest;)Ldev/mattramotar/meeseeks/runtime/TaskHandle;
 }
 
+public final class dev/mattramotar/meeseeks/runtime/CheckpointDecodeException : java/lang/IllegalStateException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class dev/mattramotar/meeseeks/runtime/CheckpointIncompatibleException : java/lang/IllegalStateException {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public abstract interface class dev/mattramotar/meeseeks/runtime/CheckpointStore {
+	public static final field Companion Ldev/mattramotar/meeseeks/runtime/CheckpointStore$Companion;
+	public static final field DEFAULT_KEY Ljava/lang/String;
+	public abstract fun clear (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun clear$default (Ldev/mattramotar/meeseeks/runtime/CheckpointStore;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun clearAll (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun read (Ljava/lang/String;Lkotlinx/serialization/KSerializer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun read$default (Ldev/mattramotar/meeseeks/runtime/CheckpointStore;Ljava/lang/String;Lkotlinx/serialization/KSerializer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun write (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/KSerializer;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun write$default (Ldev/mattramotar/meeseeks/runtime/CheckpointStore;Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/KSerializer;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class dev/mattramotar/meeseeks/runtime/CheckpointStore$Companion {
+	public static final field DEFAULT_KEY Ljava/lang/String;
+}
+
+public final class dev/mattramotar/meeseeks/runtime/CheckpointStore$DefaultImpls {
+	public static synthetic fun clear$default (Ldev/mattramotar/meeseeks/runtime/CheckpointStore;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun read$default (Ldev/mattramotar/meeseeks/runtime/CheckpointStore;Ljava/lang/String;Lkotlinx/serialization/KSerializer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun write$default (Ldev/mattramotar/meeseeks/runtime/CheckpointStore;Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/KSerializer;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class dev/mattramotar/meeseeks/runtime/CheckpointedWorker {
+	public abstract fun run (Ldev/mattramotar/meeseeks/runtime/TaskPayload;Ldev/mattramotar/meeseeks/runtime/RuntimeContext;Ldev/mattramotar/meeseeks/runtime/CheckpointStore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class dev/mattramotar/meeseeks/runtime/ConfigurationScope {
 	public final fun allowExpedited (Z)Ldev/mattramotar/meeseeks/runtime/ConfigurationScope;
 	public static synthetic fun allowExpedited$default (Ldev/mattramotar/meeseeks/runtime/ConfigurationScope;ZILjava/lang/Object;)Ldev/mattramotar/meeseeks/runtime/ConfigurationScope;
@@ -523,6 +558,7 @@ public abstract interface class dev/mattramotar/meeseeks/runtime/WorkerFactory {
 
 public abstract interface class dev/mattramotar/meeseeks/runtime/db/MeeseeksDatabase : app/cash/sqldelight/Transacter {
 	public static final field Companion Ldev/mattramotar/meeseeks/runtime/db/MeeseeksDatabase$Companion;
+	public abstract fun getTaskCheckpointQueries ()Ldev/mattramotar/meeseeks/runtime/db/TaskCheckpointQueries;
 	public abstract fun getTaskLogQueries ()Ldev/mattramotar/meeseeks/runtime/db/TaskLogQueries;
 	public abstract fun getTaskSpecQueries ()Ldev/mattramotar/meeseeks/runtime/db/TaskSpecQueries;
 }
@@ -541,6 +577,44 @@ public final class dev/mattramotar/meeseeks/runtime/db/SelectEarliestNextRunTime
 	public final fun getMIN ()Ljava/lang/Long;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/mattramotar/meeseeks/runtime/db/TaskCheckpointEntity {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;JJ)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()J
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()J
+	public final fun component9 ()J
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;JJ)Ldev/mattramotar/meeseeks/runtime/db/TaskCheckpointEntity;
+	public static synthetic fun copy$default (Ldev/mattramotar/meeseeks/runtime/db/TaskCheckpointEntity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;JJILjava/lang/Object;)Ldev/mattramotar/meeseeks/runtime/db/TaskCheckpointEntity;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCheckpoint_key ()Ljava/lang/String;
+	public final fun getCheckpoint_type_id ()Ljava/lang/String;
+	public final fun getCreated_at_ms ()J
+	public final fun getData_ ()Ljava/lang/String;
+	public final fun getPayload_type_id ()Ljava/lang/String;
+	public final fun getSchema_version ()J
+	public final fun getTask_id ()Ljava/lang/String;
+	public final fun getUpdated_at_ms ()J
+	public final fun getWorker_type_id ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/mattramotar/meeseeks/runtime/db/TaskCheckpointQueries : app/cash/sqldelight/TransacterImpl {
+	public fun <init> (Lapp/cash/sqldelight/db/SqlDriver;)V
+	public final fun countCheckpointsForTask (Ljava/lang/String;)Lapp/cash/sqldelight/Query;
+	public final fun deleteAllCheckpointsForTask (Ljava/lang/String;)V
+	public final fun deleteCheckpoint (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun insertCheckpoint (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;JJ)V
+	public final fun selectCheckpoint (Ljava/lang/String;Ljava/lang/String;)Lapp/cash/sqldelight/Query;
+	public final fun selectCheckpoint (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function9;)Lapp/cash/sqldelight/Query;
+	public final fun updateCheckpoint (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;JLjava/lang/String;Ljava/lang/String;)V
 }
 
 public final class dev/mattramotar/meeseeks/runtime/db/TaskLogEntity {

--- a/runtime/api/jvm/runtime.api
+++ b/runtime/api/jvm/runtime.api
@@ -56,10 +56,10 @@ public abstract interface class dev/mattramotar/meeseeks/runtime/CheckpointStore
 	public abstract fun clear (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun clear$default (Ldev/mattramotar/meeseeks/runtime/CheckpointStore;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public abstract fun clearAll (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun read (Ljava/lang/String;Lkotlinx/serialization/KSerializer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun read$default (Ldev/mattramotar/meeseeks/runtime/CheckpointStore;Ljava/lang/String;Lkotlinx/serialization/KSerializer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public abstract fun write (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/KSerializer;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun write$default (Ldev/mattramotar/meeseeks/runtime/CheckpointStore;Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/KSerializer;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun read (Lkotlinx/serialization/KSerializer;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun read$default (Ldev/mattramotar/meeseeks/runtime/CheckpointStore;Lkotlinx/serialization/KSerializer;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun write (Ljava/lang/Object;Lkotlinx/serialization/KSerializer;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun write$default (Ldev/mattramotar/meeseeks/runtime/CheckpointStore;Ljava/lang/Object;Lkotlinx/serialization/KSerializer;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class dev/mattramotar/meeseeks/runtime/CheckpointStore$Companion {
@@ -68,12 +68,14 @@ public final class dev/mattramotar/meeseeks/runtime/CheckpointStore$Companion {
 
 public final class dev/mattramotar/meeseeks/runtime/CheckpointStore$DefaultImpls {
 	public static synthetic fun clear$default (Ldev/mattramotar/meeseeks/runtime/CheckpointStore;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun read$default (Ldev/mattramotar/meeseeks/runtime/CheckpointStore;Ljava/lang/String;Lkotlinx/serialization/KSerializer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun write$default (Ldev/mattramotar/meeseeks/runtime/CheckpointStore;Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/KSerializer;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun read$default (Ldev/mattramotar/meeseeks/runtime/CheckpointStore;Lkotlinx/serialization/KSerializer;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun write$default (Ldev/mattramotar/meeseeks/runtime/CheckpointStore;Ljava/lang/Object;Lkotlinx/serialization/KSerializer;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
-public abstract interface class dev/mattramotar/meeseeks/runtime/CheckpointedWorker {
+public abstract class dev/mattramotar/meeseeks/runtime/CheckpointedWorker : dev/mattramotar/meeseeks/runtime/Worker {
+	public fun <init> (Ldev/mattramotar/meeseeks/runtime/AppContext;)V
 	public abstract fun run (Ldev/mattramotar/meeseeks/runtime/TaskPayload;Ldev/mattramotar/meeseeks/runtime/RuntimeContext;Ldev/mattramotar/meeseeks/runtime/CheckpointStore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun run (Ldev/mattramotar/meeseeks/runtime/TaskPayload;Ldev/mattramotar/meeseeks/runtime/RuntimeContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class dev/mattramotar/meeseeks/runtime/ConfigurationScope {
@@ -579,25 +581,23 @@ public final class dev/mattramotar/meeseeks/runtime/db/SelectEarliestNextRunTime
 }
 
 public final class dev/mattramotar/meeseeks/runtime/db/TaskCheckpointEntity {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;JJ)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JJ)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()J
-	public final fun component7 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()J
 	public final fun component8 ()J
-	public final fun component9 ()J
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;JJ)Ldev/mattramotar/meeseeks/runtime/db/TaskCheckpointEntity;
-	public static synthetic fun copy$default (Ldev/mattramotar/meeseeks/runtime/db/TaskCheckpointEntity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;JJILjava/lang/Object;)Ldev/mattramotar/meeseeks/runtime/db/TaskCheckpointEntity;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JJ)Ldev/mattramotar/meeseeks/runtime/db/TaskCheckpointEntity;
+	public static synthetic fun copy$default (Ldev/mattramotar/meeseeks/runtime/db/TaskCheckpointEntity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JJILjava/lang/Object;)Ldev/mattramotar/meeseeks/runtime/db/TaskCheckpointEntity;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCheckpoint_key ()Ljava/lang/String;
 	public final fun getCheckpoint_type_id ()Ljava/lang/String;
 	public final fun getCreated_at_ms ()J
 	public final fun getData_ ()Ljava/lang/String;
 	public final fun getPayload_type_id ()Ljava/lang/String;
-	public final fun getSchema_version ()J
 	public final fun getTask_id ()Ljava/lang/String;
 	public final fun getUpdated_at_ms ()J
 	public final fun getWorker_type_id ()Ljava/lang/String;
@@ -610,10 +610,10 @@ public final class dev/mattramotar/meeseeks/runtime/db/TaskCheckpointQueries : a
 	public final fun countCheckpointsForTask (Ljava/lang/String;)Lapp/cash/sqldelight/Query;
 	public final fun deleteAllCheckpointsForTask (Ljava/lang/String;)V
 	public final fun deleteCheckpoint (Ljava/lang/String;Ljava/lang/String;)V
-	public final fun insertCheckpoint (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;JJ)V
+	public final fun insertCheckpoint (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JJ)V
 	public final fun selectCheckpoint (Ljava/lang/String;Ljava/lang/String;)Lapp/cash/sqldelight/Query;
-	public final fun selectCheckpoint (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function9;)Lapp/cash/sqldelight/Query;
-	public final fun updateCheckpoint (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;JLjava/lang/String;Ljava/lang/String;)V
+	public final fun selectCheckpoint (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function8;)Lapp/cash/sqldelight/Query;
+	public final fun updateCheckpoint (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;)V
 }
 
 public final class dev/mattramotar/meeseeks/runtime/db/TaskLogEntity {

--- a/runtime/api/jvm/runtime.api
+++ b/runtime/api/jvm/runtime.api
@@ -41,6 +41,41 @@ public final class dev/mattramotar/meeseeks/runtime/BGTaskManagerKt {
 	public static final fun schedule (Ldev/mattramotar/meeseeks/runtime/BGTaskManager;Ldev/mattramotar/meeseeks/runtime/TaskRequest;)Ldev/mattramotar/meeseeks/runtime/TaskHandle;
 }
 
+public final class dev/mattramotar/meeseeks/runtime/CheckpointDecodeException : java/lang/IllegalStateException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class dev/mattramotar/meeseeks/runtime/CheckpointIncompatibleException : java/lang/IllegalStateException {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public abstract interface class dev/mattramotar/meeseeks/runtime/CheckpointStore {
+	public static final field Companion Ldev/mattramotar/meeseeks/runtime/CheckpointStore$Companion;
+	public static final field DEFAULT_KEY Ljava/lang/String;
+	public abstract fun clear (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun clear$default (Ldev/mattramotar/meeseeks/runtime/CheckpointStore;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun clearAll (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun read (Ljava/lang/String;Lkotlinx/serialization/KSerializer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun read$default (Ldev/mattramotar/meeseeks/runtime/CheckpointStore;Ljava/lang/String;Lkotlinx/serialization/KSerializer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun write (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/KSerializer;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun write$default (Ldev/mattramotar/meeseeks/runtime/CheckpointStore;Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/KSerializer;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class dev/mattramotar/meeseeks/runtime/CheckpointStore$Companion {
+	public static final field DEFAULT_KEY Ljava/lang/String;
+}
+
+public final class dev/mattramotar/meeseeks/runtime/CheckpointStore$DefaultImpls {
+	public static synthetic fun clear$default (Ldev/mattramotar/meeseeks/runtime/CheckpointStore;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun read$default (Ldev/mattramotar/meeseeks/runtime/CheckpointStore;Ljava/lang/String;Lkotlinx/serialization/KSerializer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun write$default (Ldev/mattramotar/meeseeks/runtime/CheckpointStore;Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/KSerializer;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class dev/mattramotar/meeseeks/runtime/CheckpointedWorker {
+	public abstract fun run (Ldev/mattramotar/meeseeks/runtime/TaskPayload;Ldev/mattramotar/meeseeks/runtime/RuntimeContext;Ldev/mattramotar/meeseeks/runtime/CheckpointStore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class dev/mattramotar/meeseeks/runtime/ConfigurationScope {
 	public final fun allowExpedited (Z)Ldev/mattramotar/meeseeks/runtime/ConfigurationScope;
 	public static synthetic fun allowExpedited$default (Ldev/mattramotar/meeseeks/runtime/ConfigurationScope;ZILjava/lang/Object;)Ldev/mattramotar/meeseeks/runtime/ConfigurationScope;
@@ -522,6 +557,7 @@ public abstract interface class dev/mattramotar/meeseeks/runtime/WorkerFactory {
 
 public abstract interface class dev/mattramotar/meeseeks/runtime/db/MeeseeksDatabase : app/cash/sqldelight/Transacter {
 	public static final field Companion Ldev/mattramotar/meeseeks/runtime/db/MeeseeksDatabase$Companion;
+	public abstract fun getTaskCheckpointQueries ()Ldev/mattramotar/meeseeks/runtime/db/TaskCheckpointQueries;
 	public abstract fun getTaskLogQueries ()Ldev/mattramotar/meeseeks/runtime/db/TaskLogQueries;
 	public abstract fun getTaskSpecQueries ()Ldev/mattramotar/meeseeks/runtime/db/TaskSpecQueries;
 }
@@ -540,6 +576,44 @@ public final class dev/mattramotar/meeseeks/runtime/db/SelectEarliestNextRunTime
 	public final fun getMIN ()Ljava/lang/Long;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/mattramotar/meeseeks/runtime/db/TaskCheckpointEntity {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;JJ)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()J
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()J
+	public final fun component9 ()J
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;JJ)Ldev/mattramotar/meeseeks/runtime/db/TaskCheckpointEntity;
+	public static synthetic fun copy$default (Ldev/mattramotar/meeseeks/runtime/db/TaskCheckpointEntity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;JJILjava/lang/Object;)Ldev/mattramotar/meeseeks/runtime/db/TaskCheckpointEntity;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCheckpoint_key ()Ljava/lang/String;
+	public final fun getCheckpoint_type_id ()Ljava/lang/String;
+	public final fun getCreated_at_ms ()J
+	public final fun getData_ ()Ljava/lang/String;
+	public final fun getPayload_type_id ()Ljava/lang/String;
+	public final fun getSchema_version ()J
+	public final fun getTask_id ()Ljava/lang/String;
+	public final fun getUpdated_at_ms ()J
+	public final fun getWorker_type_id ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/mattramotar/meeseeks/runtime/db/TaskCheckpointQueries : app/cash/sqldelight/TransacterImpl {
+	public fun <init> (Lapp/cash/sqldelight/db/SqlDriver;)V
+	public final fun countCheckpointsForTask (Ljava/lang/String;)Lapp/cash/sqldelight/Query;
+	public final fun deleteAllCheckpointsForTask (Ljava/lang/String;)V
+	public final fun deleteCheckpoint (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun insertCheckpoint (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;JJ)V
+	public final fun selectCheckpoint (Ljava/lang/String;Ljava/lang/String;)Lapp/cash/sqldelight/Query;
+	public final fun selectCheckpoint (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function9;)Lapp/cash/sqldelight/Query;
+	public final fun updateCheckpoint (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;JLjava/lang/String;Ljava/lang/String;)V
 }
 
 public final class dev/mattramotar/meeseeks/runtime/db/TaskLogEntity {

--- a/runtime/api/runtime.klib.api
+++ b/runtime/api/runtime.klib.api
@@ -78,7 +78,13 @@ abstract fun interface dev.mattramotar.meeseeks.runtime.telemetry/Telemetry { //
     abstract suspend fun onEvent(dev.mattramotar.meeseeks.runtime.telemetry/TelemetryEvent) // dev.mattramotar.meeseeks.runtime.telemetry/Telemetry.onEvent|onEvent(dev.mattramotar.meeseeks.runtime.telemetry.TelemetryEvent){}[0]
 }
 
+abstract interface <#A: dev.mattramotar.meeseeks.runtime/TaskPayload> dev.mattramotar.meeseeks.runtime/CheckpointedWorker { // dev.mattramotar.meeseeks.runtime/CheckpointedWorker|null[0]
+    abstract suspend fun run(#A, dev.mattramotar.meeseeks.runtime/RuntimeContext, dev.mattramotar.meeseeks.runtime/CheckpointStore): dev.mattramotar.meeseeks.runtime/TaskResult // dev.mattramotar.meeseeks.runtime/CheckpointedWorker.run|run(1:0;dev.mattramotar.meeseeks.runtime.RuntimeContext;dev.mattramotar.meeseeks.runtime.CheckpointStore){}[0]
+}
+
 abstract interface dev.mattramotar.meeseeks.runtime.db/MeeseeksDatabase : app.cash.sqldelight/Transacter { // dev.mattramotar.meeseeks.runtime.db/MeeseeksDatabase|null[0]
+    abstract val taskCheckpointQueries // dev.mattramotar.meeseeks.runtime.db/MeeseeksDatabase.taskCheckpointQueries|{}taskCheckpointQueries[0]
+        abstract fun <get-taskCheckpointQueries>(): dev.mattramotar.meeseeks.runtime.db/TaskCheckpointQueries // dev.mattramotar.meeseeks.runtime.db/MeeseeksDatabase.taskCheckpointQueries.<get-taskCheckpointQueries>|<get-taskCheckpointQueries>(){}[0]
     abstract val taskLogQueries // dev.mattramotar.meeseeks.runtime.db/MeeseeksDatabase.taskLogQueries|{}taskLogQueries[0]
         abstract fun <get-taskLogQueries>(): dev.mattramotar.meeseeks.runtime.db/TaskLogQueries // dev.mattramotar.meeseeks.runtime.db/MeeseeksDatabase.taskLogQueries.<get-taskLogQueries>|<get-taskLogQueries>(){}[0]
     abstract val taskSpecQueries // dev.mattramotar.meeseeks.runtime.db/MeeseeksDatabase.taskSpecQueries|{}taskSpecQueries[0]
@@ -109,6 +115,18 @@ abstract interface dev.mattramotar.meeseeks.runtime/BGTaskManager { // dev.mattr
     abstract fun reschedule(dev.mattramotar.meeseeks.runtime/TaskId, dev.mattramotar.meeseeks.runtime/TaskRequest): dev.mattramotar.meeseeks.runtime/TaskId // dev.mattramotar.meeseeks.runtime/BGTaskManager.reschedule|reschedule(dev.mattramotar.meeseeks.runtime.TaskId;dev.mattramotar.meeseeks.runtime.TaskRequest){}[0]
     abstract fun reschedulePendingTasks() // dev.mattramotar.meeseeks.runtime/BGTaskManager.reschedulePendingTasks|reschedulePendingTasks(){}[0]
     abstract fun schedule(dev.mattramotar.meeseeks.runtime/TaskRequest): dev.mattramotar.meeseeks.runtime/TaskId // dev.mattramotar.meeseeks.runtime/BGTaskManager.schedule|schedule(dev.mattramotar.meeseeks.runtime.TaskRequest){}[0]
+}
+
+abstract interface dev.mattramotar.meeseeks.runtime/CheckpointStore { // dev.mattramotar.meeseeks.runtime/CheckpointStore|null[0]
+    abstract suspend fun <#A1: kotlin/Any> read(kotlin/String = ..., kotlinx.serialization/KSerializer<#A1>): #A1? // dev.mattramotar.meeseeks.runtime/CheckpointStore.read|read(kotlin.String;kotlinx.serialization.KSerializer<0:0>){0§<kotlin.Any>}[0]
+    abstract suspend fun <#A1: kotlin/Any> write(kotlin/String = ..., #A1, kotlinx.serialization/KSerializer<#A1>, kotlin/Int = ...) // dev.mattramotar.meeseeks.runtime/CheckpointStore.write|write(kotlin.String;0:0;kotlinx.serialization.KSerializer<0:0>;kotlin.Int){0§<kotlin.Any>}[0]
+    abstract suspend fun clear(kotlin/String = ...) // dev.mattramotar.meeseeks.runtime/CheckpointStore.clear|clear(kotlin.String){}[0]
+    abstract suspend fun clearAll() // dev.mattramotar.meeseeks.runtime/CheckpointStore.clearAll|clearAll(){}[0]
+
+    final object Companion { // dev.mattramotar.meeseeks.runtime/CheckpointStore.Companion|null[0]
+        final const val DEFAULT_KEY // dev.mattramotar.meeseeks.runtime/CheckpointStore.Companion.DEFAULT_KEY|{}DEFAULT_KEY[0]
+            final fun <get-DEFAULT_KEY>(): kotlin/String // dev.mattramotar.meeseeks.runtime/CheckpointStore.Companion.DEFAULT_KEY.<get-DEFAULT_KEY>|<get-DEFAULT_KEY>(){}[0]
+    }
 }
 
 abstract interface dev.mattramotar.meeseeks.runtime/PayloadCipher { // dev.mattramotar.meeseeks.runtime/PayloadCipher|null[0]
@@ -174,6 +192,55 @@ final class dev.mattramotar.meeseeks.runtime.db/SelectEarliestNextRunTime { // d
     final fun equals(kotlin/Any?): kotlin/Boolean // dev.mattramotar.meeseeks.runtime.db/SelectEarliestNextRunTime.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // dev.mattramotar.meeseeks.runtime.db/SelectEarliestNextRunTime.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // dev.mattramotar.meeseeks.runtime.db/SelectEarliestNextRunTime.toString|toString(){}[0]
+}
+
+final class dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity { // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity|null[0]
+    constructor <init>(kotlin/String, kotlin/String, kotlin/String, kotlin/String, kotlin/String, kotlin/Long, kotlin/String, kotlin/Long, kotlin/Long) // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.<init>|<init>(kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.Long;kotlin.String;kotlin.Long;kotlin.Long){}[0]
+
+    final val checkpoint_key // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.checkpoint_key|{}checkpoint_key[0]
+        final fun <get-checkpoint_key>(): kotlin/String // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.checkpoint_key.<get-checkpoint_key>|<get-checkpoint_key>(){}[0]
+    final val checkpoint_type_id // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.checkpoint_type_id|{}checkpoint_type_id[0]
+        final fun <get-checkpoint_type_id>(): kotlin/String // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.checkpoint_type_id.<get-checkpoint_type_id>|<get-checkpoint_type_id>(){}[0]
+    final val created_at_ms // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.created_at_ms|{}created_at_ms[0]
+        final fun <get-created_at_ms>(): kotlin/Long // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.created_at_ms.<get-created_at_ms>|<get-created_at_ms>(){}[0]
+    final val data_ // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.data_|{}data_[0]
+        final fun <get-data_>(): kotlin/String // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.data_.<get-data_>|<get-data_>(){}[0]
+    final val payload_type_id // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.payload_type_id|{}payload_type_id[0]
+        final fun <get-payload_type_id>(): kotlin/String // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.payload_type_id.<get-payload_type_id>|<get-payload_type_id>(){}[0]
+    final val schema_version // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.schema_version|{}schema_version[0]
+        final fun <get-schema_version>(): kotlin/Long // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.schema_version.<get-schema_version>|<get-schema_version>(){}[0]
+    final val task_id // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.task_id|{}task_id[0]
+        final fun <get-task_id>(): kotlin/String // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.task_id.<get-task_id>|<get-task_id>(){}[0]
+    final val updated_at_ms // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.updated_at_ms|{}updated_at_ms[0]
+        final fun <get-updated_at_ms>(): kotlin/Long // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.updated_at_ms.<get-updated_at_ms>|<get-updated_at_ms>(){}[0]
+    final val worker_type_id // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.worker_type_id|{}worker_type_id[0]
+        final fun <get-worker_type_id>(): kotlin/String // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.worker_type_id.<get-worker_type_id>|<get-worker_type_id>(){}[0]
+
+    final fun component1(): kotlin/String // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.component1|component1(){}[0]
+    final fun component2(): kotlin/String // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.component2|component2(){}[0]
+    final fun component3(): kotlin/String // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.component3|component3(){}[0]
+    final fun component4(): kotlin/String // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.component4|component4(){}[0]
+    final fun component5(): kotlin/String // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.component5|component5(){}[0]
+    final fun component6(): kotlin/Long // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.component6|component6(){}[0]
+    final fun component7(): kotlin/String // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.component7|component7(){}[0]
+    final fun component8(): kotlin/Long // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.component8|component8(){}[0]
+    final fun component9(): kotlin/Long // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.component9|component9(){}[0]
+    final fun copy(kotlin/String = ..., kotlin/String = ..., kotlin/String = ..., kotlin/String = ..., kotlin/String = ..., kotlin/Long = ..., kotlin/String = ..., kotlin/Long = ..., kotlin/Long = ...): dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.copy|copy(kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.Long;kotlin.String;kotlin.Long;kotlin.Long){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.toString|toString(){}[0]
+}
+
+final class dev.mattramotar.meeseeks.runtime.db/TaskCheckpointQueries : app.cash.sqldelight/TransacterImpl { // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointQueries|null[0]
+    constructor <init>(app.cash.sqldelight.db/SqlDriver) // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointQueries.<init>|<init>(app.cash.sqldelight.db.SqlDriver){}[0]
+
+    final fun <#A1: kotlin/Any> selectCheckpoint(kotlin/String, kotlin/String, kotlin/Function9<kotlin/String, kotlin/String, kotlin/String, kotlin/String, kotlin/String, kotlin/Long, kotlin/String, kotlin/Long, kotlin/Long, #A1>): app.cash.sqldelight/Query<#A1> // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointQueries.selectCheckpoint|selectCheckpoint(kotlin.String;kotlin.String;kotlin.Function9<kotlin.String,kotlin.String,kotlin.String,kotlin.String,kotlin.String,kotlin.Long,kotlin.String,kotlin.Long,kotlin.Long,0:0>){0§<kotlin.Any>}[0]
+    final fun countCheckpointsForTask(kotlin/String): app.cash.sqldelight/Query<kotlin/Long> // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointQueries.countCheckpointsForTask|countCheckpointsForTask(kotlin.String){}[0]
+    final fun deleteAllCheckpointsForTask(kotlin/String) // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointQueries.deleteAllCheckpointsForTask|deleteAllCheckpointsForTask(kotlin.String){}[0]
+    final fun deleteCheckpoint(kotlin/String, kotlin/String) // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointQueries.deleteCheckpoint|deleteCheckpoint(kotlin.String;kotlin.String){}[0]
+    final fun insertCheckpoint(kotlin/String, kotlin/String, kotlin/String, kotlin/String, kotlin/String, kotlin/Long, kotlin/String, kotlin/Long, kotlin/Long) // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointQueries.insertCheckpoint|insertCheckpoint(kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.Long;kotlin.String;kotlin.Long;kotlin.Long){}[0]
+    final fun selectCheckpoint(kotlin/String, kotlin/String): app.cash.sqldelight/Query<dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity> // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointQueries.selectCheckpoint|selectCheckpoint(kotlin.String;kotlin.String){}[0]
+    final fun updateCheckpoint(kotlin/String, kotlin/String, kotlin/String, kotlin/Long, kotlin/String, kotlin/Long, kotlin/String, kotlin/String) // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointQueries.updateCheckpoint|updateCheckpoint(kotlin.String;kotlin.String;kotlin.String;kotlin.Long;kotlin.String;kotlin.Long;kotlin.String;kotlin.String){}[0]
 }
 
 final class dev.mattramotar.meeseeks.runtime.db/TaskLogEntity { // dev.mattramotar.meeseeks.runtime.db/TaskLogEntity|null[0]
@@ -834,6 +901,14 @@ final class dev.mattramotar.meeseeks.runtime/BGTaskManagerConfig { // dev.mattra
     final fun equals(kotlin/Any?): kotlin/Boolean // dev.mattramotar.meeseeks.runtime/BGTaskManagerConfig.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // dev.mattramotar.meeseeks.runtime/BGTaskManagerConfig.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // dev.mattramotar.meeseeks.runtime/BGTaskManagerConfig.toString|toString(){}[0]
+}
+
+final class dev.mattramotar.meeseeks.runtime/CheckpointDecodeException : kotlin/IllegalStateException { // dev.mattramotar.meeseeks.runtime/CheckpointDecodeException|null[0]
+    constructor <init>(kotlin/String, kotlin/Throwable? = ...) // dev.mattramotar.meeseeks.runtime/CheckpointDecodeException.<init>|<init>(kotlin.String;kotlin.Throwable?){}[0]
+}
+
+final class dev.mattramotar.meeseeks.runtime/CheckpointIncompatibleException : kotlin/IllegalStateException { // dev.mattramotar.meeseeks.runtime/CheckpointIncompatibleException|null[0]
+    constructor <init>(kotlin/String) // dev.mattramotar.meeseeks.runtime/CheckpointIncompatibleException.<init>|<init>(kotlin.String){}[0]
 }
 
 final class dev.mattramotar.meeseeks.runtime/ConfigurationScope { // dev.mattramotar.meeseeks.runtime/ConfigurationScope|null[0]
@@ -1560,6 +1635,8 @@ final fun (dev.mattramotar.meeseeks.runtime/BGTaskManager).dev.mattramotar.meese
 final fun dev.mattramotar.meeseeks.runtime/schedule(dev.mattramotar.meeseeks.runtime/BGTaskManager, dev.mattramotar.meeseeks.runtime/TaskRequest): dev.mattramotar.meeseeks.runtime/TaskHandle // dev.mattramotar.meeseeks.runtime/schedule|schedule(dev.mattramotar.meeseeks.runtime.BGTaskManager;dev.mattramotar.meeseeks.runtime.TaskRequest){}[0]
 final inline fun <#A: reified dev.mattramotar.meeseeks.runtime/TaskPayload> (dev.mattramotar.meeseeks.runtime/BGTaskManager).dev.mattramotar.meeseeks.runtime/oneTime(#A, kotlin.time/Duration = ..., noinline kotlin/Function1<dev.mattramotar.meeseeks.runtime.dsl/OneTimeTaskRequestConfigurationScope<#A>, kotlin/Unit> = ...): dev.mattramotar.meeseeks.runtime/TaskHandle // dev.mattramotar.meeseeks.runtime/oneTime|oneTime@dev.mattramotar.meeseeks.runtime.BGTaskManager(0:0;kotlin.time.Duration;kotlin.Function1<dev.mattramotar.meeseeks.runtime.dsl.OneTimeTaskRequestConfigurationScope<0:0>,kotlin.Unit>){0§<dev.mattramotar.meeseeks.runtime.TaskPayload>}[0]
 final inline fun <#A: reified dev.mattramotar.meeseeks.runtime/TaskPayload> (dev.mattramotar.meeseeks.runtime/BGTaskManager).dev.mattramotar.meeseeks.runtime/periodic(#A, kotlin.time/Duration, kotlin.time/Duration = ..., kotlin.time/Duration = ..., noinline kotlin/Function1<dev.mattramotar.meeseeks.runtime.dsl/PeriodicTaskRequestConfigurationScope<#A>, kotlin/Unit> = ...): dev.mattramotar.meeseeks.runtime/TaskHandle // dev.mattramotar.meeseeks.runtime/periodic|periodic@dev.mattramotar.meeseeks.runtime.BGTaskManager(0:0;kotlin.time.Duration;kotlin.time.Duration;kotlin.time.Duration;kotlin.Function1<dev.mattramotar.meeseeks.runtime.dsl.PeriodicTaskRequestConfigurationScope<0:0>,kotlin.Unit>){0§<dev.mattramotar.meeseeks.runtime.TaskPayload>}[0]
+final suspend inline fun <#A: reified kotlin/Any> (dev.mattramotar.meeseeks.runtime/CheckpointStore).dev.mattramotar.meeseeks.runtime/read(kotlin/String = ...): #A? // dev.mattramotar.meeseeks.runtime/read|read@dev.mattramotar.meeseeks.runtime.CheckpointStore(kotlin.String){0§<kotlin.Any>}[0]
+final suspend inline fun <#A: reified kotlin/Any> (dev.mattramotar.meeseeks.runtime/CheckpointStore).dev.mattramotar.meeseeks.runtime/write(#A, kotlin/String = ..., kotlin/Int = ...) // dev.mattramotar.meeseeks.runtime/write|write@dev.mattramotar.meeseeks.runtime.CheckpointStore(0:0;kotlin.String;kotlin.Int){0§<kotlin.Any>}[0]
 
 // Targets: [ios]
 final object dev.mattramotar.meeseeks.runtime/BGTaskIdentifiers { // dev.mattramotar.meeseeks.runtime/BGTaskIdentifiers|null[0]

--- a/runtime/api/runtime.klib.api
+++ b/runtime/api/runtime.klib.api
@@ -78,10 +78,6 @@ abstract fun interface dev.mattramotar.meeseeks.runtime.telemetry/Telemetry { //
     abstract suspend fun onEvent(dev.mattramotar.meeseeks.runtime.telemetry/TelemetryEvent) // dev.mattramotar.meeseeks.runtime.telemetry/Telemetry.onEvent|onEvent(dev.mattramotar.meeseeks.runtime.telemetry.TelemetryEvent){}[0]
 }
 
-abstract interface <#A: dev.mattramotar.meeseeks.runtime/TaskPayload> dev.mattramotar.meeseeks.runtime/CheckpointedWorker { // dev.mattramotar.meeseeks.runtime/CheckpointedWorker|null[0]
-    abstract suspend fun run(#A, dev.mattramotar.meeseeks.runtime/RuntimeContext, dev.mattramotar.meeseeks.runtime/CheckpointStore): dev.mattramotar.meeseeks.runtime/TaskResult // dev.mattramotar.meeseeks.runtime/CheckpointedWorker.run|run(1:0;dev.mattramotar.meeseeks.runtime.RuntimeContext;dev.mattramotar.meeseeks.runtime.CheckpointStore){}[0]
-}
-
 abstract interface dev.mattramotar.meeseeks.runtime.db/MeeseeksDatabase : app.cash.sqldelight/Transacter { // dev.mattramotar.meeseeks.runtime.db/MeeseeksDatabase|null[0]
     abstract val taskCheckpointQueries // dev.mattramotar.meeseeks.runtime.db/MeeseeksDatabase.taskCheckpointQueries|{}taskCheckpointQueries[0]
         abstract fun <get-taskCheckpointQueries>(): dev.mattramotar.meeseeks.runtime.db/TaskCheckpointQueries // dev.mattramotar.meeseeks.runtime.db/MeeseeksDatabase.taskCheckpointQueries.<get-taskCheckpointQueries>|<get-taskCheckpointQueries>(){}[0]
@@ -118,8 +114,8 @@ abstract interface dev.mattramotar.meeseeks.runtime/BGTaskManager { // dev.mattr
 }
 
 abstract interface dev.mattramotar.meeseeks.runtime/CheckpointStore { // dev.mattramotar.meeseeks.runtime/CheckpointStore|null[0]
-    abstract suspend fun <#A1: kotlin/Any> read(kotlin/String = ..., kotlinx.serialization/KSerializer<#A1>): #A1? // dev.mattramotar.meeseeks.runtime/CheckpointStore.read|read(kotlin.String;kotlinx.serialization.KSerializer<0:0>){0§<kotlin.Any>}[0]
-    abstract suspend fun <#A1: kotlin/Any> write(kotlin/String = ..., #A1, kotlinx.serialization/KSerializer<#A1>, kotlin/Int = ...) // dev.mattramotar.meeseeks.runtime/CheckpointStore.write|write(kotlin.String;0:0;kotlinx.serialization.KSerializer<0:0>;kotlin.Int){0§<kotlin.Any>}[0]
+    abstract suspend fun <#A1: kotlin/Any> read(kotlinx.serialization/KSerializer<#A1>, kotlin/String = ...): #A1? // dev.mattramotar.meeseeks.runtime/CheckpointStore.read|read(kotlinx.serialization.KSerializer<0:0>;kotlin.String){0§<kotlin.Any>}[0]
+    abstract suspend fun <#A1: kotlin/Any> write(#A1, kotlinx.serialization/KSerializer<#A1>, kotlin/String = ...) // dev.mattramotar.meeseeks.runtime/CheckpointStore.write|write(0:0;kotlinx.serialization.KSerializer<0:0>;kotlin.String){0§<kotlin.Any>}[0]
     abstract suspend fun clear(kotlin/String = ...) // dev.mattramotar.meeseeks.runtime/CheckpointStore.clear|clear(kotlin.String){}[0]
     abstract suspend fun clearAll() // dev.mattramotar.meeseeks.runtime/CheckpointStore.clearAll|clearAll(){}[0]
 
@@ -150,6 +146,13 @@ abstract interface dev.mattramotar.meeseeks.runtime/TaskHandle { // dev.mattramo
 }
 
 abstract interface dev.mattramotar.meeseeks.runtime/TaskPayload // dev.mattramotar.meeseeks.runtime/TaskPayload|null[0]
+
+abstract class <#A: dev.mattramotar.meeseeks.runtime/TaskPayload> dev.mattramotar.meeseeks.runtime/CheckpointedWorker : dev.mattramotar.meeseeks.runtime/Worker<#A> { // dev.mattramotar.meeseeks.runtime/CheckpointedWorker|null[0]
+    constructor <init>(dev.mattramotar.meeseeks.runtime/AppContext) // dev.mattramotar.meeseeks.runtime/CheckpointedWorker.<init>|<init>(dev.mattramotar.meeseeks.runtime.AppContext){}[0]
+
+    abstract suspend fun run(#A, dev.mattramotar.meeseeks.runtime/RuntimeContext, dev.mattramotar.meeseeks.runtime/CheckpointStore): dev.mattramotar.meeseeks.runtime/TaskResult // dev.mattramotar.meeseeks.runtime/CheckpointedWorker.run|run(1:0;dev.mattramotar.meeseeks.runtime.RuntimeContext;dev.mattramotar.meeseeks.runtime.CheckpointStore){}[0]
+    final suspend fun run(#A, dev.mattramotar.meeseeks.runtime/RuntimeContext): dev.mattramotar.meeseeks.runtime/TaskResult // dev.mattramotar.meeseeks.runtime/CheckpointedWorker.run|run(1:0;dev.mattramotar.meeseeks.runtime.RuntimeContext){}[0]
+}
 
 abstract class <#A: dev.mattramotar.meeseeks.runtime/TaskPayload> dev.mattramotar.meeseeks.runtime/Worker { // dev.mattramotar.meeseeks.runtime/Worker|null[0]
     constructor <init>(dev.mattramotar.meeseeks.runtime/AppContext) // dev.mattramotar.meeseeks.runtime/Worker.<init>|<init>(dev.mattramotar.meeseeks.runtime.AppContext){}[0]
@@ -195,7 +198,7 @@ final class dev.mattramotar.meeseeks.runtime.db/SelectEarliestNextRunTime { // d
 }
 
 final class dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity { // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity|null[0]
-    constructor <init>(kotlin/String, kotlin/String, kotlin/String, kotlin/String, kotlin/String, kotlin/Long, kotlin/String, kotlin/Long, kotlin/Long) // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.<init>|<init>(kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.Long;kotlin.String;kotlin.Long;kotlin.Long){}[0]
+    constructor <init>(kotlin/String, kotlin/String, kotlin/String, kotlin/String, kotlin/String, kotlin/String, kotlin/Long, kotlin/Long) // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.<init>|<init>(kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.Long;kotlin.Long){}[0]
 
     final val checkpoint_key // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.checkpoint_key|{}checkpoint_key[0]
         final fun <get-checkpoint_key>(): kotlin/String // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.checkpoint_key.<get-checkpoint_key>|<get-checkpoint_key>(){}[0]
@@ -207,8 +210,6 @@ final class dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity { // dev.ma
         final fun <get-data_>(): kotlin/String // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.data_.<get-data_>|<get-data_>(){}[0]
     final val payload_type_id // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.payload_type_id|{}payload_type_id[0]
         final fun <get-payload_type_id>(): kotlin/String // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.payload_type_id.<get-payload_type_id>|<get-payload_type_id>(){}[0]
-    final val schema_version // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.schema_version|{}schema_version[0]
-        final fun <get-schema_version>(): kotlin/Long // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.schema_version.<get-schema_version>|<get-schema_version>(){}[0]
     final val task_id // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.task_id|{}task_id[0]
         final fun <get-task_id>(): kotlin/String // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.task_id.<get-task_id>|<get-task_id>(){}[0]
     final val updated_at_ms // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.updated_at_ms|{}updated_at_ms[0]
@@ -221,11 +222,10 @@ final class dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity { // dev.ma
     final fun component3(): kotlin/String // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.component3|component3(){}[0]
     final fun component4(): kotlin/String // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.component4|component4(){}[0]
     final fun component5(): kotlin/String // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.component5|component5(){}[0]
-    final fun component6(): kotlin/Long // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.component6|component6(){}[0]
-    final fun component7(): kotlin/String // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.component7|component7(){}[0]
+    final fun component6(): kotlin/String // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.component6|component6(){}[0]
+    final fun component7(): kotlin/Long // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.component7|component7(){}[0]
     final fun component8(): kotlin/Long // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.component8|component8(){}[0]
-    final fun component9(): kotlin/Long // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.component9|component9(){}[0]
-    final fun copy(kotlin/String = ..., kotlin/String = ..., kotlin/String = ..., kotlin/String = ..., kotlin/String = ..., kotlin/Long = ..., kotlin/String = ..., kotlin/Long = ..., kotlin/Long = ...): dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.copy|copy(kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.Long;kotlin.String;kotlin.Long;kotlin.Long){}[0]
+    final fun copy(kotlin/String = ..., kotlin/String = ..., kotlin/String = ..., kotlin/String = ..., kotlin/String = ..., kotlin/String = ..., kotlin/Long = ..., kotlin/Long = ...): dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.copy|copy(kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.Long;kotlin.Long){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity.toString|toString(){}[0]
@@ -234,13 +234,13 @@ final class dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity { // dev.ma
 final class dev.mattramotar.meeseeks.runtime.db/TaskCheckpointQueries : app.cash.sqldelight/TransacterImpl { // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointQueries|null[0]
     constructor <init>(app.cash.sqldelight.db/SqlDriver) // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointQueries.<init>|<init>(app.cash.sqldelight.db.SqlDriver){}[0]
 
-    final fun <#A1: kotlin/Any> selectCheckpoint(kotlin/String, kotlin/String, kotlin/Function9<kotlin/String, kotlin/String, kotlin/String, kotlin/String, kotlin/String, kotlin/Long, kotlin/String, kotlin/Long, kotlin/Long, #A1>): app.cash.sqldelight/Query<#A1> // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointQueries.selectCheckpoint|selectCheckpoint(kotlin.String;kotlin.String;kotlin.Function9<kotlin.String,kotlin.String,kotlin.String,kotlin.String,kotlin.String,kotlin.Long,kotlin.String,kotlin.Long,kotlin.Long,0:0>){0§<kotlin.Any>}[0]
+    final fun <#A1: kotlin/Any> selectCheckpoint(kotlin/String, kotlin/String, kotlin/Function8<kotlin/String, kotlin/String, kotlin/String, kotlin/String, kotlin/String, kotlin/String, kotlin/Long, kotlin/Long, #A1>): app.cash.sqldelight/Query<#A1> // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointQueries.selectCheckpoint|selectCheckpoint(kotlin.String;kotlin.String;kotlin.Function8<kotlin.String,kotlin.String,kotlin.String,kotlin.String,kotlin.String,kotlin.String,kotlin.Long,kotlin.Long,0:0>){0§<kotlin.Any>}[0]
     final fun countCheckpointsForTask(kotlin/String): app.cash.sqldelight/Query<kotlin/Long> // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointQueries.countCheckpointsForTask|countCheckpointsForTask(kotlin.String){}[0]
     final fun deleteAllCheckpointsForTask(kotlin/String) // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointQueries.deleteAllCheckpointsForTask|deleteAllCheckpointsForTask(kotlin.String){}[0]
     final fun deleteCheckpoint(kotlin/String, kotlin/String) // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointQueries.deleteCheckpoint|deleteCheckpoint(kotlin.String;kotlin.String){}[0]
-    final fun insertCheckpoint(kotlin/String, kotlin/String, kotlin/String, kotlin/String, kotlin/String, kotlin/Long, kotlin/String, kotlin/Long, kotlin/Long) // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointQueries.insertCheckpoint|insertCheckpoint(kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.Long;kotlin.String;kotlin.Long;kotlin.Long){}[0]
+    final fun insertCheckpoint(kotlin/String, kotlin/String, kotlin/String, kotlin/String, kotlin/String, kotlin/String, kotlin/Long, kotlin/Long) // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointQueries.insertCheckpoint|insertCheckpoint(kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.Long;kotlin.Long){}[0]
     final fun selectCheckpoint(kotlin/String, kotlin/String): app.cash.sqldelight/Query<dev.mattramotar.meeseeks.runtime.db/TaskCheckpointEntity> // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointQueries.selectCheckpoint|selectCheckpoint(kotlin.String;kotlin.String){}[0]
-    final fun updateCheckpoint(kotlin/String, kotlin/String, kotlin/String, kotlin/Long, kotlin/String, kotlin/Long, kotlin/String, kotlin/String) // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointQueries.updateCheckpoint|updateCheckpoint(kotlin.String;kotlin.String;kotlin.String;kotlin.Long;kotlin.String;kotlin.Long;kotlin.String;kotlin.String){}[0]
+    final fun updateCheckpoint(kotlin/String, kotlin/String, kotlin/String, kotlin/String, kotlin/Long, kotlin/String, kotlin/String) // dev.mattramotar.meeseeks.runtime.db/TaskCheckpointQueries.updateCheckpoint|updateCheckpoint(kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.Long;kotlin.String;kotlin.String){}[0]
 }
 
 final class dev.mattramotar.meeseeks.runtime.db/TaskLogEntity { // dev.mattramotar.meeseeks.runtime.db/TaskLogEntity|null[0]
@@ -1636,7 +1636,7 @@ final fun dev.mattramotar.meeseeks.runtime/schedule(dev.mattramotar.meeseeks.run
 final inline fun <#A: reified dev.mattramotar.meeseeks.runtime/TaskPayload> (dev.mattramotar.meeseeks.runtime/BGTaskManager).dev.mattramotar.meeseeks.runtime/oneTime(#A, kotlin.time/Duration = ..., noinline kotlin/Function1<dev.mattramotar.meeseeks.runtime.dsl/OneTimeTaskRequestConfigurationScope<#A>, kotlin/Unit> = ...): dev.mattramotar.meeseeks.runtime/TaskHandle // dev.mattramotar.meeseeks.runtime/oneTime|oneTime@dev.mattramotar.meeseeks.runtime.BGTaskManager(0:0;kotlin.time.Duration;kotlin.Function1<dev.mattramotar.meeseeks.runtime.dsl.OneTimeTaskRequestConfigurationScope<0:0>,kotlin.Unit>){0§<dev.mattramotar.meeseeks.runtime.TaskPayload>}[0]
 final inline fun <#A: reified dev.mattramotar.meeseeks.runtime/TaskPayload> (dev.mattramotar.meeseeks.runtime/BGTaskManager).dev.mattramotar.meeseeks.runtime/periodic(#A, kotlin.time/Duration, kotlin.time/Duration = ..., kotlin.time/Duration = ..., noinline kotlin/Function1<dev.mattramotar.meeseeks.runtime.dsl/PeriodicTaskRequestConfigurationScope<#A>, kotlin/Unit> = ...): dev.mattramotar.meeseeks.runtime/TaskHandle // dev.mattramotar.meeseeks.runtime/periodic|periodic@dev.mattramotar.meeseeks.runtime.BGTaskManager(0:0;kotlin.time.Duration;kotlin.time.Duration;kotlin.time.Duration;kotlin.Function1<dev.mattramotar.meeseeks.runtime.dsl.PeriodicTaskRequestConfigurationScope<0:0>,kotlin.Unit>){0§<dev.mattramotar.meeseeks.runtime.TaskPayload>}[0]
 final suspend inline fun <#A: reified kotlin/Any> (dev.mattramotar.meeseeks.runtime/CheckpointStore).dev.mattramotar.meeseeks.runtime/read(kotlin/String = ...): #A? // dev.mattramotar.meeseeks.runtime/read|read@dev.mattramotar.meeseeks.runtime.CheckpointStore(kotlin.String){0§<kotlin.Any>}[0]
-final suspend inline fun <#A: reified kotlin/Any> (dev.mattramotar.meeseeks.runtime/CheckpointStore).dev.mattramotar.meeseeks.runtime/write(#A, kotlin/String = ..., kotlin/Int = ...) // dev.mattramotar.meeseeks.runtime/write|write@dev.mattramotar.meeseeks.runtime.CheckpointStore(0:0;kotlin.String;kotlin.Int){0§<kotlin.Any>}[0]
+final suspend inline fun <#A: reified kotlin/Any> (dev.mattramotar.meeseeks.runtime/CheckpointStore).dev.mattramotar.meeseeks.runtime/write(#A, kotlin/String = ...) // dev.mattramotar.meeseeks.runtime/write|write@dev.mattramotar.meeseeks.runtime.CheckpointStore(0:0;kotlin.String){0§<kotlin.Any>}[0]
 
 // Targets: [ios]
 final object dev.mattramotar.meeseeks.runtime/BGTaskIdentifiers { // dev.mattramotar.meeseeks.runtime/BGTaskIdentifiers|null[0]

--- a/runtime/src/commonMain/kotlin/dev/mattramotar/meeseeks/runtime/CheckpointStore.kt
+++ b/runtime/src/commonMain/kotlin/dev/mattramotar/meeseeks/runtime/CheckpointStore.kt
@@ -1,0 +1,57 @@
+package dev.mattramotar.meeseeks.runtime
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.serializer
+
+/**
+ * Durable app-level checkpoint storage for a running task.
+ *
+ * Checkpoints are serializable progress markers owned by worker code. They are
+ * retained across retry and process restart, then cleared when the task reaches
+ * terminal success, permanent failure, or cancellation.
+ */
+public interface CheckpointStore {
+    public suspend fun <T : Any> read(
+        key: String = DEFAULT_KEY,
+        serializer: KSerializer<T>,
+    ): T?
+
+    public suspend fun <T : Any> write(
+        key: String = DEFAULT_KEY,
+        value: T,
+        serializer: KSerializer<T>,
+        schemaVersion: Int = 1,
+    )
+
+    public suspend fun clear(key: String = DEFAULT_KEY)
+
+    public suspend fun clearAll()
+
+    public companion object {
+        public const val DEFAULT_KEY: String = "default"
+    }
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+public suspend inline fun <reified T : Any> CheckpointStore.read(
+    key: String = CheckpointStore.DEFAULT_KEY,
+): T? = read(key, serializer<T>())
+
+@OptIn(ExperimentalSerializationApi::class)
+public suspend inline fun <reified T : Any> CheckpointStore.write(
+    value: T,
+    key: String = CheckpointStore.DEFAULT_KEY,
+    schemaVersion: Int = 1,
+) {
+    write(key, value, serializer<T>(), schemaVersion)
+}
+
+public class CheckpointDecodeException(
+    message: String,
+    cause: Throwable? = null,
+) : IllegalStateException(message, cause)
+
+public class CheckpointIncompatibleException(
+    message: String,
+) : IllegalStateException(message)

--- a/runtime/src/commonMain/kotlin/dev/mattramotar/meeseeks/runtime/CheckpointStore.kt
+++ b/runtime/src/commonMain/kotlin/dev/mattramotar/meeseeks/runtime/CheckpointStore.kt
@@ -10,18 +10,20 @@ import kotlinx.serialization.serializer
  * Checkpoints are serializable progress markers owned by worker code. They are
  * retained across retry and process restart, then cleared when the task reaches
  * terminal success, permanent failure, or cancellation.
+ *
+ * Workers own checkpoint schema evolution: put a version field inside your own
+ * `@Serializable` checkpoint class when its shape may change between releases.
  */
 public interface CheckpointStore {
     public suspend fun <T : Any> read(
-        key: String = DEFAULT_KEY,
         serializer: KSerializer<T>,
+        key: String = DEFAULT_KEY,
     ): T?
 
     public suspend fun <T : Any> write(
-        key: String = DEFAULT_KEY,
         value: T,
         serializer: KSerializer<T>,
-        schemaVersion: Int = 1,
+        key: String = DEFAULT_KEY,
     )
 
     public suspend fun clear(key: String = DEFAULT_KEY)
@@ -36,15 +38,14 @@ public interface CheckpointStore {
 @OptIn(ExperimentalSerializationApi::class)
 public suspend inline fun <reified T : Any> CheckpointStore.read(
     key: String = CheckpointStore.DEFAULT_KEY,
-): T? = read(key, serializer<T>())
+): T? = read(serializer<T>(), key)
 
 @OptIn(ExperimentalSerializationApi::class)
 public suspend inline fun <reified T : Any> CheckpointStore.write(
     value: T,
     key: String = CheckpointStore.DEFAULT_KEY,
-    schemaVersion: Int = 1,
 ) {
-    write(key, value, serializer<T>(), schemaVersion)
+    write(value, serializer<T>(), key)
 }
 
 public class CheckpointDecodeException(

--- a/runtime/src/commonMain/kotlin/dev/mattramotar/meeseeks/runtime/CheckpointedWorker.kt
+++ b/runtime/src/commonMain/kotlin/dev/mattramotar/meeseeks/runtime/CheckpointedWorker.kt
@@ -1,13 +1,32 @@
 package dev.mattramotar.meeseeks.runtime
 
 /**
- * Worker capability for resumable app-level progress.
+ * Base class for workers with resumable app-level progress.
  *
- * Existing workers keep using [Worker.run]. Workers that also implement this
- * interface receive a [CheckpointStore] when Meeseeks executes them.
+ * Subclasses receive a [CheckpointStore] when Meeseeks executes them and can
+ * persist progress markers that survive retries and process restarts. Existing
+ * workers keep extending [Worker]; checkpointing is opt-in via this class.
+ *
+ * Extending [Worker] (rather than adding a separate capability interface) ties
+ * the payload type of the worker and its checkpoint-aware entry point together
+ * and spares subclasses from overriding the two-argument [Worker.run], which
+ * Meeseeks never invokes for checkpointed workers.
  */
-public interface CheckpointedWorker<T : TaskPayload> {
-    public suspend fun run(
+public abstract class CheckpointedWorker<T : TaskPayload>(
+    appContext: AppContext,
+) : Worker<T>(appContext) {
+
+    /**
+     * Meeseeks always executes checkpointed workers through the
+     * three-argument [run] with a [CheckpointStore]. Unit tests for a
+     * checkpointed worker should call that overload with a fake store.
+     */
+    final override suspend fun run(payload: T, context: RuntimeContext): TaskResult =
+        throw UnsupportedOperationException(
+            "CheckpointedWorker executes through run(payload, context, checkpoints)."
+        )
+
+    public abstract suspend fun run(
         payload: T,
         context: RuntimeContext,
         checkpoints: CheckpointStore,

--- a/runtime/src/commonMain/kotlin/dev/mattramotar/meeseeks/runtime/CheckpointedWorker.kt
+++ b/runtime/src/commonMain/kotlin/dev/mattramotar/meeseeks/runtime/CheckpointedWorker.kt
@@ -1,0 +1,15 @@
+package dev.mattramotar.meeseeks.runtime
+
+/**
+ * Worker capability for resumable app-level progress.
+ *
+ * Existing workers keep using [Worker.run]. Workers that also implement this
+ * interface receive a [CheckpointStore] when Meeseeks executes them.
+ */
+public interface CheckpointedWorker<T : TaskPayload> {
+    public suspend fun run(
+        payload: T,
+        context: RuntimeContext,
+        checkpoints: CheckpointStore,
+    ): TaskResult
+}

--- a/runtime/src/commonMain/kotlin/dev/mattramotar/meeseeks/runtime/internal/RealBGTaskManager.kt
+++ b/runtime/src/commonMain/kotlin/dev/mattramotar/meeseeks/runtime/internal/RealBGTaskManager.kt
@@ -185,8 +185,9 @@ internal class RealBGTaskManager(
 
     /**
      * Atomically cancels a task unless it already reached a terminal state, and
-     * logs the durable Cancelled event only when this call performed the
-     * cancellation. Returns false for tasks that were already terminal.
+     * logs the durable Cancelled event and clears checkpoints only when this
+     * call performed the cancellation. Returns false for tasks that were
+     * already terminal.
      */
     private fun cancelInDatabase(taskId: String, attempt: Long, message: String): Boolean {
         val cancelledAt = Timestamp.now()
@@ -201,6 +202,7 @@ internal class RealBGTaskManager(
                     attempt = attempt,
                     message = message
                 )
+                database.taskCheckpointQueries.deleteAllCheckpointsForTask(taskId)
             }
             cancelled
         }

--- a/runtime/src/commonMain/kotlin/dev/mattramotar/meeseeks/runtime/internal/RealCheckpointStore.kt
+++ b/runtime/src/commonMain/kotlin/dev/mattramotar/meeseeks/runtime/internal/RealCheckpointStore.kt
@@ -5,6 +5,8 @@ import dev.mattramotar.meeseeks.runtime.CheckpointIncompatibleException
 import dev.mattramotar.meeseeks.runtime.CheckpointStore
 import dev.mattramotar.meeseeks.runtime.db.MeeseeksDatabase
 import dev.mattramotar.meeseeks.runtime.db.TaskCheckpointEntity
+import dev.mattramotar.meeseeks.runtime.internal.coroutines.MeeseeksDispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.KSerializer
 
 internal class RealCheckpointStore(
@@ -16,17 +18,17 @@ internal class RealCheckpointStore(
 ) : CheckpointStore {
 
     override suspend fun <T : Any> read(
-        key: String,
         serializer: KSerializer<T>,
-    ): T? {
+        key: String,
+    ): T? = withContext(MeeseeksDispatchers.IO) {
         val row = database.taskCheckpointQueries
             .selectCheckpoint(taskId, key)
-            .executeAsOneOrNull() ?: return null
+            .executeAsOneOrNull() ?: return@withContext null
 
         val expectedCheckpointTypeId = registry.checkpointTypeId(serializer)
         validateCompatibility(row, key, expectedCheckpointTypeId)
 
-        return try {
+        try {
             registry.deserializeCheckpoint(serializer, row.data_)
         } catch (error: Throwable) {
             throw CheckpointDecodeException(
@@ -37,53 +39,54 @@ internal class RealCheckpointStore(
     }
 
     override suspend fun <T : Any> write(
-        key: String,
         value: T,
         serializer: KSerializer<T>,
-        schemaVersion: Int,
+        key: String,
     ) {
-        require(schemaVersion > 0) { "schemaVersion must be positive." }
-
         val checkpoint = registry.serializeCheckpoint(serializer, value)
         val now = Timestamp.now()
-        database.transaction {
-            val existing = database.taskCheckpointQueries
-                .selectCheckpoint(taskId, key)
-                .executeAsOneOrNull()
+        withContext(MeeseeksDispatchers.IO) {
+            database.transaction {
+                val existing = database.taskCheckpointQueries
+                    .selectCheckpoint(taskId, key)
+                    .executeAsOneOrNull()
 
-            if (existing == null) {
-                database.taskCheckpointQueries.insertCheckpoint(
-                    task_id = taskId,
-                    checkpoint_key = key,
-                    payload_type_id = payloadTypeId,
-                    worker_type_id = workerTypeId,
-                    checkpoint_type_id = checkpoint.typeId,
-                    schema_version = schemaVersion.toLong(),
-                    data_ = checkpoint.data,
-                    created_at_ms = now,
-                    updated_at_ms = now,
-                )
-            } else {
-                database.taskCheckpointQueries.updateCheckpoint(
-                    payload_type_id = payloadTypeId,
-                    worker_type_id = workerTypeId,
-                    checkpoint_type_id = checkpoint.typeId,
-                    schema_version = schemaVersion.toLong(),
-                    data_ = checkpoint.data,
-                    updated_at_ms = now,
-                    task_id = taskId,
-                    checkpoint_key = key,
-                )
+                if (existing == null) {
+                    database.taskCheckpointQueries.insertCheckpoint(
+                        task_id = taskId,
+                        checkpoint_key = key,
+                        payload_type_id = payloadTypeId,
+                        worker_type_id = workerTypeId,
+                        checkpoint_type_id = checkpoint.typeId,
+                        data_ = checkpoint.data,
+                        created_at_ms = now,
+                        updated_at_ms = now,
+                    )
+                } else {
+                    database.taskCheckpointQueries.updateCheckpoint(
+                        payload_type_id = payloadTypeId,
+                        worker_type_id = workerTypeId,
+                        checkpoint_type_id = checkpoint.typeId,
+                        data_ = checkpoint.data,
+                        updated_at_ms = now,
+                        task_id = taskId,
+                        checkpoint_key = key,
+                    )
+                }
             }
         }
     }
 
     override suspend fun clear(key: String) {
-        database.taskCheckpointQueries.deleteCheckpoint(taskId, key)
+        withContext(MeeseeksDispatchers.IO) {
+            database.taskCheckpointQueries.deleteCheckpoint(taskId, key)
+        }
     }
 
     override suspend fun clearAll() {
-        database.taskCheckpointQueries.deleteAllCheckpointsForTask(taskId)
+        withContext(MeeseeksDispatchers.IO) {
+            database.taskCheckpointQueries.deleteAllCheckpointsForTask(taskId)
+        }
     }
 
     private fun validateCompatibility(

--- a/runtime/src/commonMain/kotlin/dev/mattramotar/meeseeks/runtime/internal/RealCheckpointStore.kt
+++ b/runtime/src/commonMain/kotlin/dev/mattramotar/meeseeks/runtime/internal/RealCheckpointStore.kt
@@ -1,0 +1,130 @@
+package dev.mattramotar.meeseeks.runtime.internal
+
+import dev.mattramotar.meeseeks.runtime.CheckpointDecodeException
+import dev.mattramotar.meeseeks.runtime.CheckpointIncompatibleException
+import dev.mattramotar.meeseeks.runtime.CheckpointStore
+import dev.mattramotar.meeseeks.runtime.db.MeeseeksDatabase
+import dev.mattramotar.meeseeks.runtime.db.TaskCheckpointEntity
+import kotlinx.serialization.KSerializer
+
+internal class RealCheckpointStore(
+    private val database: MeeseeksDatabase,
+    private val registry: WorkerRegistry,
+    private val taskId: String,
+    private val payloadTypeId: String,
+    private val workerTypeId: String,
+) : CheckpointStore {
+
+    override suspend fun <T : Any> read(
+        key: String,
+        serializer: KSerializer<T>,
+    ): T? {
+        val row = database.taskCheckpointQueries
+            .selectCheckpoint(taskId, key)
+            .executeAsOneOrNull() ?: return null
+
+        val expectedCheckpointTypeId = registry.checkpointTypeId(serializer)
+        validateCompatibility(row, key, expectedCheckpointTypeId)
+
+        return try {
+            registry.deserializeCheckpoint(serializer, row.data_)
+        } catch (error: Throwable) {
+            throw CheckpointDecodeException(
+                message = "Could not decode checkpoint '$key' for task '$taskId' as '$expectedCheckpointTypeId'.",
+                cause = error,
+            )
+        }
+    }
+
+    override suspend fun <T : Any> write(
+        key: String,
+        value: T,
+        serializer: KSerializer<T>,
+        schemaVersion: Int,
+    ) {
+        require(schemaVersion > 0) { "schemaVersion must be positive." }
+
+        val checkpoint = registry.serializeCheckpoint(serializer, value)
+        val now = Timestamp.now()
+        database.transaction {
+            val existing = database.taskCheckpointQueries
+                .selectCheckpoint(taskId, key)
+                .executeAsOneOrNull()
+
+            if (existing == null) {
+                database.taskCheckpointQueries.insertCheckpoint(
+                    task_id = taskId,
+                    checkpoint_key = key,
+                    payload_type_id = payloadTypeId,
+                    worker_type_id = workerTypeId,
+                    checkpoint_type_id = checkpoint.typeId,
+                    schema_version = schemaVersion.toLong(),
+                    data_ = checkpoint.data,
+                    created_at_ms = now,
+                    updated_at_ms = now,
+                )
+            } else {
+                database.taskCheckpointQueries.updateCheckpoint(
+                    payload_type_id = payloadTypeId,
+                    worker_type_id = workerTypeId,
+                    checkpoint_type_id = checkpoint.typeId,
+                    schema_version = schemaVersion.toLong(),
+                    data_ = checkpoint.data,
+                    updated_at_ms = now,
+                    task_id = taskId,
+                    checkpoint_key = key,
+                )
+            }
+        }
+    }
+
+    override suspend fun clear(key: String) {
+        database.taskCheckpointQueries.deleteCheckpoint(taskId, key)
+    }
+
+    override suspend fun clearAll() {
+        database.taskCheckpointQueries.deleteAllCheckpointsForTask(taskId)
+    }
+
+    private fun validateCompatibility(
+        row: TaskCheckpointEntity,
+        key: String,
+        expectedCheckpointTypeId: String,
+    ) {
+        if (row.payload_type_id != payloadTypeId) {
+            throw incompatible(
+                key = key,
+                expected = payloadTypeId,
+                actual = row.payload_type_id,
+                field = "payload type",
+            )
+        }
+        if (row.worker_type_id != workerTypeId) {
+            throw incompatible(
+                key = key,
+                expected = workerTypeId,
+                actual = row.worker_type_id,
+                field = "worker type",
+            )
+        }
+        if (row.checkpoint_type_id != expectedCheckpointTypeId) {
+            throw incompatible(
+                key = key,
+                expected = expectedCheckpointTypeId,
+                actual = row.checkpoint_type_id,
+                field = "checkpoint type",
+            )
+        }
+    }
+
+    private fun incompatible(
+        key: String,
+        field: String,
+        expected: String,
+        actual: String,
+    ): CheckpointIncompatibleException {
+        return CheckpointIncompatibleException(
+            "Checkpoint '$key' for task '$taskId' has incompatible $field: expected '$expected', found '$actual'."
+        )
+    }
+}

--- a/runtime/src/commonMain/kotlin/dev/mattramotar/meeseeks/runtime/internal/TaskExecutor.kt
+++ b/runtime/src/commonMain/kotlin/dev/mattramotar/meeseeks/runtime/internal/TaskExecutor.kt
@@ -2,6 +2,7 @@ package dev.mattramotar.meeseeks.runtime.internal
 
 import dev.mattramotar.meeseeks.runtime.AppContext
 import dev.mattramotar.meeseeks.runtime.BGTaskManagerConfig
+import dev.mattramotar.meeseeks.runtime.CheckpointedWorker
 import dev.mattramotar.meeseeks.runtime.RuntimeContext
 import dev.mattramotar.meeseeks.runtime.TaskId
 import dev.mattramotar.meeseeks.runtime.TaskPayload
@@ -90,7 +91,15 @@ internal object TaskExecutor {
             )
         )
 
-        val result = executeWorker(request, registry, appContext, effectiveAttemptCount)
+        val result = executeWorker(
+            taskId = taskId,
+            request = request,
+            registry = registry,
+            appContext = appContext,
+            database = database,
+            payloadTypeId = claimed.payload_type_id,
+            effectiveAttemptCount = effectiveAttemptCount
+        )
 
         val taskSpec = database.taskSpecQueries.selectTaskById(taskId).executeAsOneOrNull()
         val maxRetries = taskSpec?.max_retries?.toInt() ?: 3
@@ -235,17 +244,38 @@ internal object TaskExecutor {
      * Execute the worker for the given task request.
      */
     private suspend fun executeWorker(
+        taskId: String,
         request: TaskRequest,
         registry: WorkerRegistry,
         appContext: AppContext,
-        attemptCount: Int
+        database: MeeseeksDatabase,
+        payloadTypeId: String,
+        effectiveAttemptCount: Int
     ): TaskResult {
         return try {
-            val factory = registry.getFactory(request.payload::class)
+            val registration = registry.getRegistration(request.payload::class)
 
             @Suppress("UNCHECKED_CAST")
-            val worker = factory.create(appContext) as Worker<TaskPayload>
-            worker.run(request.payload, RuntimeContext(attemptCount))
+            val worker = registration.factory.create(appContext) as Worker<TaskPayload>
+            val context = RuntimeContext(effectiveAttemptCount)
+
+            if (worker is CheckpointedWorker<*>) {
+                @Suppress("UNCHECKED_CAST")
+                val checkpointedWorker = worker as CheckpointedWorker<TaskPayload>
+                checkpointedWorker.run(
+                    payload = request.payload,
+                    context = context,
+                    checkpoints = RealCheckpointStore(
+                        database = database,
+                        registry = registry,
+                        taskId = taskId,
+                        payloadTypeId = payloadTypeId,
+                        workerTypeId = registration.typeId,
+                    ),
+                )
+            } else {
+                worker.run(request.payload, context)
+            }
         } catch (error: Throwable) {
             classifyError(error)
         }
@@ -276,11 +306,14 @@ internal object TaskExecutor {
     ): ExecutionResult {
         return when (val schedule = request.schedule) {
             is TaskSchedule.OneTime -> {
-                database.taskSpecQueries.updateState(
-                    state = TaskState.SUCCEEDED.toDbValue(),
-                    updated_at_ms = Timestamp.now(),
-                    id = taskId
-                )
+                database.transaction {
+                    database.taskSpecQueries.updateState(
+                        state = TaskState.SUCCEEDED.toDbValue(),
+                        updated_at_ms = Timestamp.now(),
+                        id = taskId
+                    )
+                    database.taskCheckpointQueries.deleteAllCheckpointsForTask(taskId)
+                }
 
                 config?.telemetry?.onEvent(
                     TelemetryEvent.TaskSucceeded(
@@ -300,12 +333,15 @@ internal object TaskExecutor {
                 val jitter = if (flex.isPositive()) (0..flex.inWholeMilliseconds).random().milliseconds else Duration.ZERO
                 val delay = (base - flex + jitter).coerceAtLeast(Duration.ZERO)
 
-                database.taskSpecQueries.updateStateAndNextRunTime(
-                    state = TaskState.ENQUEUED.toDbValue(),
-                    updated_at_ms = now,
-                    next_run_time_ms = now + delay.inWholeMilliseconds,
-                    id = taskId
-                )
+                database.transaction {
+                    database.taskSpecQueries.updateStateAndNextRunTime(
+                        state = TaskState.ENQUEUED.toDbValue(),
+                        updated_at_ms = now,
+                        next_run_time_ms = now + delay.inWholeMilliseconds,
+                        id = taskId
+                    )
+                    database.taskCheckpointQueries.deleteAllCheckpointsForTask(taskId)
+                }
 
                 config?.telemetry?.onEvent(
                     TelemetryEvent.TaskSucceeded(
@@ -332,11 +368,14 @@ internal object TaskExecutor {
         database: MeeseeksDatabase,
         config: BGTaskManagerConfig?
     ) {
-        database.taskSpecQueries.updateState(
-            state = TaskState.FAILED.toDbValue(),
-            updated_at_ms = Timestamp.now(),
-            id = taskId
-        )
+        database.transaction {
+            database.taskSpecQueries.updateState(
+                state = TaskState.FAILED.toDbValue(),
+                updated_at_ms = Timestamp.now(),
+                id = taskId
+            )
+            database.taskCheckpointQueries.deleteAllCheckpointsForTask(taskId)
+        }
 
         config?.telemetry?.onEvent(
             TelemetryEvent.TaskFailed(

--- a/runtime/src/commonMain/kotlin/dev/mattramotar/meeseeks/runtime/internal/WorkerRegistry.kt
+++ b/runtime/src/commonMain/kotlin/dev/mattramotar/meeseeks/runtime/internal/WorkerRegistry.kt
@@ -5,6 +5,7 @@ import dev.mattramotar.meeseeks.runtime.PayloadCipher
 import dev.mattramotar.meeseeks.runtime.TaskPayload
 import dev.mattramotar.meeseeks.runtime.Worker
 import dev.mattramotar.meeseeks.runtime.WorkerFactory
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
 import kotlin.reflect.KClass
@@ -22,10 +23,14 @@ internal class WorkerRegistry(
     private val registrationsByTypeId = registrations.values.associateBy { it.typeId }
 
     fun <T : TaskPayload> getFactory(payloadClass: KClass<T>): WorkerFactory<T> {
-        val registration = registrations[payloadClass]
+        val registration = getRegistration(payloadClass)
 
         @Suppress("UNCHECKED_CAST")
-        return registration?.factory as? WorkerFactory<T>
+        return registration.factory as WorkerFactory<T>
+    }
+
+    fun <T : TaskPayload> getRegistration(payloadClass: KClass<T>): WorkerRegistration {
+        return registrations[payloadClass]
             ?: throw IllegalArgumentException("No Worker registered for Payload type: ${payloadClass.simpleName}. Ensure it was added in BGTaskManagerBuilder.")
     }
 
@@ -52,6 +57,27 @@ internal class WorkerRegistry(
         val serializer = registration.serializer as KSerializer<TaskPayload>
         val decrypted = decryptPayload(data)
         return json.decodeFromString(serializer, decrypted)
+    }
+
+    @OptIn(ExperimentalSerializationApi::class)
+    fun <T : Any> serializeCheckpoint(
+        serializer: KSerializer<T>,
+        value: T
+    ): SerializedPayload {
+        val data = json.encodeToString(serializer, value)
+        return SerializedPayload(checkpointTypeId(serializer), encryptPayload(data))
+    }
+
+    fun <T : Any> deserializeCheckpoint(
+        serializer: KSerializer<T>,
+        data: String
+    ): T {
+        return json.decodeFromString(serializer, decryptPayload(data))
+    }
+
+    @OptIn(ExperimentalSerializationApi::class)
+    fun <T : Any> checkpointTypeId(serializer: KSerializer<T>): String {
+        return serializer.descriptor.serialName
     }
 
     internal fun getAllRegistrations(): Collection<WorkerRegistration> = registrations.values

--- a/runtime/src/commonMain/sqldelight/dev/mattramotar/meeseeks/runtime/db/TaskCheckpoint.sq
+++ b/runtime/src/commonMain/sqldelight/dev/mattramotar/meeseeks/runtime/db/TaskCheckpoint.sq
@@ -1,0 +1,56 @@
+CREATE TABLE taskCheckpointEntity (
+    task_id TEXT NOT NULL,
+    checkpoint_key TEXT NOT NULL,
+    payload_type_id TEXT NOT NULL,
+    worker_type_id TEXT NOT NULL,
+    checkpoint_type_id TEXT NOT NULL,
+    schema_version INTEGER NOT NULL,
+    data TEXT NOT NULL,
+    created_at_ms INTEGER NOT NULL,
+    updated_at_ms INTEGER NOT NULL,
+    PRIMARY KEY (task_id, checkpoint_key),
+    FOREIGN KEY (task_id) REFERENCES taskSpec(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_taskCheckpointEntity_task_id ON taskCheckpointEntity(task_id);
+
+selectCheckpoint:
+SELECT * FROM taskCheckpointEntity
+WHERE task_id = ? AND checkpoint_key = ?;
+
+insertCheckpoint:
+INSERT INTO taskCheckpointEntity(
+    task_id,
+    checkpoint_key,
+    payload_type_id,
+    worker_type_id,
+    checkpoint_type_id,
+    schema_version,
+    data,
+    created_at_ms,
+    updated_at_ms
+)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
+
+updateCheckpoint:
+UPDATE taskCheckpointEntity
+SET
+    payload_type_id = ?,
+    worker_type_id = ?,
+    checkpoint_type_id = ?,
+    schema_version = ?,
+    data = ?,
+    updated_at_ms = ?
+WHERE task_id = ? AND checkpoint_key = ?;
+
+deleteCheckpoint:
+DELETE FROM taskCheckpointEntity
+WHERE task_id = ? AND checkpoint_key = ?;
+
+deleteAllCheckpointsForTask:
+DELETE FROM taskCheckpointEntity
+WHERE task_id = ?;
+
+countCheckpointsForTask:
+SELECT COUNT(*) FROM taskCheckpointEntity
+WHERE task_id = ?;

--- a/runtime/src/commonMain/sqldelight/dev/mattramotar/meeseeks/runtime/db/TaskCheckpoint.sq
+++ b/runtime/src/commonMain/sqldelight/dev/mattramotar/meeseeks/runtime/db/TaskCheckpoint.sq
@@ -1,18 +1,17 @@
+-- The composite primary key on (task_id, checkpoint_key) serves WHERE task_id
+-- lookups through its left prefix, so no separate index on task_id is needed.
 CREATE TABLE taskCheckpointEntity (
     task_id TEXT NOT NULL,
     checkpoint_key TEXT NOT NULL,
     payload_type_id TEXT NOT NULL,
     worker_type_id TEXT NOT NULL,
     checkpoint_type_id TEXT NOT NULL,
-    schema_version INTEGER NOT NULL,
     data TEXT NOT NULL,
     created_at_ms INTEGER NOT NULL,
     updated_at_ms INTEGER NOT NULL,
     PRIMARY KEY (task_id, checkpoint_key),
     FOREIGN KEY (task_id) REFERENCES taskSpec(id) ON DELETE CASCADE
 );
-
-CREATE INDEX idx_taskCheckpointEntity_task_id ON taskCheckpointEntity(task_id);
 
 selectCheckpoint:
 SELECT * FROM taskCheckpointEntity
@@ -25,12 +24,11 @@ INSERT INTO taskCheckpointEntity(
     payload_type_id,
     worker_type_id,
     checkpoint_type_id,
-    schema_version,
     data,
     created_at_ms,
     updated_at_ms
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
+VALUES (?, ?, ?, ?, ?, ?, ?, ?);
 
 updateCheckpoint:
 UPDATE taskCheckpointEntity
@@ -38,7 +36,6 @@ SET
     payload_type_id = ?,
     worker_type_id = ?,
     checkpoint_type_id = ?,
-    schema_version = ?,
     data = ?,
     updated_at_ms = ?
 WHERE task_id = ? AND checkpoint_key = ?;

--- a/runtime/src/commonMain/sqldelight/dev/mattramotar/meeseeks/runtime/db/migrations/4.sqm
+++ b/runtime/src/commonMain/sqldelight/dev/mattramotar/meeseeks/runtime/db/migrations/4.sqm
@@ -1,0 +1,15 @@
+CREATE TABLE taskCheckpointEntity (
+    task_id TEXT NOT NULL,
+    checkpoint_key TEXT NOT NULL,
+    payload_type_id TEXT NOT NULL,
+    worker_type_id TEXT NOT NULL,
+    checkpoint_type_id TEXT NOT NULL,
+    schema_version INTEGER NOT NULL,
+    data TEXT NOT NULL,
+    created_at_ms INTEGER NOT NULL,
+    updated_at_ms INTEGER NOT NULL,
+    PRIMARY KEY (task_id, checkpoint_key),
+    FOREIGN KEY (task_id) REFERENCES taskSpec(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_taskCheckpointEntity_task_id ON taskCheckpointEntity(task_id);

--- a/runtime/src/commonMain/sqldelight/dev/mattramotar/meeseeks/runtime/db/migrations/4.sqm
+++ b/runtime/src/commonMain/sqldelight/dev/mattramotar/meeseeks/runtime/db/migrations/4.sqm
@@ -4,12 +4,9 @@ CREATE TABLE taskCheckpointEntity (
     payload_type_id TEXT NOT NULL,
     worker_type_id TEXT NOT NULL,
     checkpoint_type_id TEXT NOT NULL,
-    schema_version INTEGER NOT NULL,
     data TEXT NOT NULL,
     created_at_ms INTEGER NOT NULL,
     updated_at_ms INTEGER NOT NULL,
     PRIMARY KEY (task_id, checkpoint_key),
     FOREIGN KEY (task_id) REFERENCES taskSpec(id) ON DELETE CASCADE
 );
-
-CREATE INDEX idx_taskCheckpointEntity_task_id ON taskCheckpointEntity(task_id);

--- a/runtime/src/jvmTest/kotlin/dev/mattramotar/meeseeks/runtime/internal/CheckpointPersistenceJvmTest.kt
+++ b/runtime/src/jvmTest/kotlin/dev/mattramotar/meeseeks/runtime/internal/CheckpointPersistenceJvmTest.kt
@@ -138,7 +138,7 @@ class CheckpointPersistenceJvmTest {
             insertTask(database, registry, taskId)
             val store = checkpointStore(database, registry, taskId)
 
-            store.write("cursor", Progress(1), Progress.serializer())
+            store.write(Progress(1), Progress.serializer(), "cursor")
 
             assertEquals(1L, checkpointCount(database, taskId))
 
@@ -158,16 +158,16 @@ class CheckpointPersistenceJvmTest {
         insertTask(database, registry, taskId)
         val store = checkpointStore(database, registry, taskId)
 
-        store.write("cursor", Progress(1), Progress.serializer())
-        store.write("cursor", Progress(2), Progress.serializer())
-        store.write("side", Progress(3), Progress.serializer())
+        store.write(Progress(1), Progress.serializer(), "cursor")
+        store.write(Progress(2), Progress.serializer(), "cursor")
+        store.write(Progress(3), Progress.serializer(), "side")
 
-        assertEquals(Progress(2), store.read("cursor", Progress.serializer()))
+        assertEquals(Progress(2), store.read(Progress.serializer(), "cursor"))
         assertEquals(2L, checkpointCount(database, taskId))
 
         store.clear("cursor")
 
-        assertNull(store.read("cursor", Progress.serializer()))
+        assertNull(store.read(Progress.serializer(), "cursor"))
         assertEquals(1L, checkpointCount(database, taskId))
 
         store.clearAll()
@@ -183,17 +183,16 @@ class CheckpointPersistenceJvmTest {
         insertTask(database, registry, taskId)
         val store = checkpointStore(database, registry, taskId)
 
-        store.write("cursor", Progress(1), Progress.serializer())
+        store.write(Progress(1), Progress.serializer(), "cursor")
 
         assertFailsWith<CheckpointIncompatibleException> {
-            store.read("cursor", OtherProgress.serializer())
+            store.read(OtherProgress.serializer(), "cursor")
         }
 
         database.taskCheckpointQueries.updateCheckpoint(
             payload_type_id = payloadTypeId(),
             worker_type_id = payloadTypeId(),
             checkpoint_type_id = registry.checkpointTypeId(Progress.serializer()),
-            schema_version = 1L,
             data_ = "not-json",
             updated_at_ms = 1L,
             task_id = taskId,
@@ -201,18 +200,14 @@ class CheckpointPersistenceJvmTest {
         )
 
         assertFailsWith<CheckpointDecodeException> {
-            store.read("cursor", Progress.serializer())
+            store.read(Progress.serializer(), "cursor")
         }
     }
 
     private class ResumableWorker(
         appContext: AppContext,
         private val observed: MutableList<Progress?>,
-    ) : Worker<ResumePayload>(appContext), CheckpointedWorker<ResumePayload> {
-
-        override suspend fun run(payload: ResumePayload, context: RuntimeContext): TaskResult {
-            error("Checkpointed workers must use the checkpoint-aware run method.")
-        }
+    ) : CheckpointedWorker<ResumePayload>(appContext) {
 
         override suspend fun run(
             payload: ResumePayload,
@@ -233,18 +228,14 @@ class CheckpointPersistenceJvmTest {
     private class ResultWorker(
         appContext: AppContext,
         private val result: TaskResult,
-    ) : Worker<ResumePayload>(appContext), CheckpointedWorker<ResumePayload> {
-
-        override suspend fun run(payload: ResumePayload, context: RuntimeContext): TaskResult {
-            error("Checkpointed workers must use the checkpoint-aware run method.")
-        }
+    ) : CheckpointedWorker<ResumePayload>(appContext) {
 
         override suspend fun run(
             payload: ResumePayload,
             context: RuntimeContext,
             checkpoints: CheckpointStore,
         ): TaskResult {
-            checkpoints.write(Progress(context.attemptCount), schemaVersion = 1)
+            checkpoints.write(Progress(context.attemptCount))
             return result
         }
     }

--- a/runtime/src/jvmTest/kotlin/dev/mattramotar/meeseeks/runtime/internal/CheckpointPersistenceJvmTest.kt
+++ b/runtime/src/jvmTest/kotlin/dev/mattramotar/meeseeks/runtime/internal/CheckpointPersistenceJvmTest.kt
@@ -1,0 +1,376 @@
+package dev.mattramotar.meeseeks.runtime.internal
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import dev.mattramotar.meeseeks.runtime.AppContext
+import dev.mattramotar.meeseeks.runtime.BGTaskManagerConfig
+import dev.mattramotar.meeseeks.runtime.CheckpointDecodeException
+import dev.mattramotar.meeseeks.runtime.CheckpointIncompatibleException
+import dev.mattramotar.meeseeks.runtime.CheckpointStore
+import dev.mattramotar.meeseeks.runtime.CheckpointedWorker
+import dev.mattramotar.meeseeks.runtime.RuntimeContext
+import dev.mattramotar.meeseeks.runtime.TaskId
+import dev.mattramotar.meeseeks.runtime.TaskPayload
+import dev.mattramotar.meeseeks.runtime.TaskRequest
+import dev.mattramotar.meeseeks.runtime.TaskResult
+import dev.mattramotar.meeseeks.runtime.TaskRetryPolicy
+import dev.mattramotar.meeseeks.runtime.Worker
+import dev.mattramotar.meeseeks.runtime.WorkerFactory
+import dev.mattramotar.meeseeks.runtime.db.MeeseeksDatabase
+import dev.mattramotar.meeseeks.runtime.db.TaskSpec
+import dev.mattramotar.meeseeks.runtime.internal.db.TaskMapper
+import dev.mattramotar.meeseeks.runtime.internal.db.adapters.taskLogEntityAdapter
+import dev.mattramotar.meeseeks.runtime.read
+import dev.mattramotar.meeseeks.runtime.write
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.quartz.Scheduler
+import org.quartz.impl.StdSchedulerFactory
+import java.util.Properties
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+@OptIn(ExperimentalSerializationApi::class)
+class CheckpointPersistenceJvmTest {
+
+    private object TestAppContext : AppContext()
+
+    @Serializable
+    private data class ResumePayload(val id: String) : TaskPayload
+
+    @Serializable
+    private data class Progress(val completedStep: Int)
+
+    @Serializable
+    private data class OtherProgress(val value: String)
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+    }
+
+    @Test
+    fun checkpointedWorkerReadsCheckpointOnRetryAndSuccessClearsIt() = runTest {
+        val database = database()
+        val observed = mutableListOf<Progress?>()
+        val registry = registry { appContext -> ResumableWorker(appContext, observed) }
+        val taskId = "retry-resume-task"
+
+        insertTask(database, registry, taskId)
+
+        val firstResult = TaskExecutor.execute(
+            taskId = taskId,
+            database = database,
+            registry = registry,
+            appContext = TestAppContext,
+            config = BGTaskManagerConfig()
+        )
+
+        assertIs<TaskExecutor.ExecutionResult.ScheduleNextActivation>(firstResult)
+        assertEquals(1L, checkpointCount(database, taskId))
+
+        val restartedRegistry = registry { appContext -> ResumableWorker(appContext, observed) }
+        val secondResult = TaskExecutor.execute(
+            taskId = taskId,
+            database = database,
+            registry = restartedRegistry,
+            appContext = TestAppContext,
+            config = BGTaskManagerConfig()
+        )
+
+        assertEquals(TaskExecutor.ExecutionResult.Terminal.Success, secondResult)
+        assertEquals(listOf(null, Progress(1)), observed)
+        assertEquals(0L, checkpointCount(database, taskId))
+    }
+
+    @Test
+    fun checkpointsSurviveTransientFailureAndClearOnPermanentFailure() = runTest {
+        val database = database()
+        val taskId = "terminal-cleanup-task"
+        val transientRegistry = registry { appContext ->
+            ResultWorker(appContext, TaskResult.Failure.Transient(RuntimeException("retry")))
+        }
+
+        insertTask(database, transientRegistry, taskId)
+
+        val transientResult = TaskExecutor.execute(
+            taskId = taskId,
+            database = database,
+            registry = transientRegistry,
+            appContext = TestAppContext,
+            config = BGTaskManagerConfig()
+        )
+
+        assertIs<TaskExecutor.ExecutionResult.ScheduleNextActivation>(transientResult)
+        assertEquals(1L, checkpointCount(database, taskId))
+
+        val permanentRegistry = registry { appContext ->
+            ResultWorker(appContext, TaskResult.Failure.Permanent(RuntimeException("done")))
+        }
+        val permanentResult = TaskExecutor.execute(
+            taskId = taskId,
+            database = database,
+            registry = permanentRegistry,
+            appContext = TestAppContext,
+            config = BGTaskManagerConfig()
+        )
+
+        assertEquals(TaskExecutor.ExecutionResult.Terminal.Failure, permanentResult)
+        assertEquals(0L, checkpointCount(database, taskId))
+    }
+
+    @Test
+    fun cancelClearsCheckpoints() = runTest {
+        val database = database()
+        val registry = registry { appContext -> ResultWorker(appContext, TaskResult.Success) }
+        val scheduler = createInMemoryScheduler()
+
+        try {
+            val manager = manager(database, registry, scheduler)
+            val taskId = "cancel-cleanup-task"
+            insertTask(database, registry, taskId)
+            val store = checkpointStore(database, registry, taskId)
+
+            store.write("cursor", Progress(1), Progress.serializer())
+
+            assertEquals(1L, checkpointCount(database, taskId))
+
+            manager.cancel(TaskId(taskId))
+
+            assertEquals(0L, checkpointCount(database, taskId))
+        } finally {
+            scheduler.shutdown(true)
+        }
+    }
+
+    @Test
+    fun checkpointStoreOverwritesAndClearsKeys() = runTest {
+        val database = database()
+        val registry = registry { appContext -> ResultWorker(appContext, TaskResult.Success) }
+        val taskId = "store-overwrite-task"
+        insertTask(database, registry, taskId)
+        val store = checkpointStore(database, registry, taskId)
+
+        store.write("cursor", Progress(1), Progress.serializer())
+        store.write("cursor", Progress(2), Progress.serializer())
+        store.write("side", Progress(3), Progress.serializer())
+
+        assertEquals(Progress(2), store.read("cursor", Progress.serializer()))
+        assertEquals(2L, checkpointCount(database, taskId))
+
+        store.clear("cursor")
+
+        assertNull(store.read("cursor", Progress.serializer()))
+        assertEquals(1L, checkpointCount(database, taskId))
+
+        store.clearAll()
+
+        assertEquals(0L, checkpointCount(database, taskId))
+    }
+
+    @Test
+    fun checkpointStoreReportsIncompatibleAndCorruptData() = runTest {
+        val database = database()
+        val registry = registry { appContext -> ResultWorker(appContext, TaskResult.Success) }
+        val taskId = "store-error-task"
+        insertTask(database, registry, taskId)
+        val store = checkpointStore(database, registry, taskId)
+
+        store.write("cursor", Progress(1), Progress.serializer())
+
+        assertFailsWith<CheckpointIncompatibleException> {
+            store.read("cursor", OtherProgress.serializer())
+        }
+
+        database.taskCheckpointQueries.updateCheckpoint(
+            payload_type_id = payloadTypeId(),
+            worker_type_id = payloadTypeId(),
+            checkpoint_type_id = registry.checkpointTypeId(Progress.serializer()),
+            schema_version = 1L,
+            data_ = "not-json",
+            updated_at_ms = 1L,
+            task_id = taskId,
+            checkpoint_key = "cursor",
+        )
+
+        assertFailsWith<CheckpointDecodeException> {
+            store.read("cursor", Progress.serializer())
+        }
+    }
+
+    private class ResumableWorker(
+        appContext: AppContext,
+        private val observed: MutableList<Progress?>,
+    ) : Worker<ResumePayload>(appContext), CheckpointedWorker<ResumePayload> {
+
+        override suspend fun run(payload: ResumePayload, context: RuntimeContext): TaskResult {
+            error("Checkpointed workers must use the checkpoint-aware run method.")
+        }
+
+        override suspend fun run(
+            payload: ResumePayload,
+            context: RuntimeContext,
+            checkpoints: CheckpointStore,
+        ): TaskResult {
+            val progress = checkpoints.read<Progress>()
+            observed += progress
+            return if (progress == null) {
+                checkpoints.write(Progress(1))
+                TaskResult.Retry
+            } else {
+                TaskResult.Success
+            }
+        }
+    }
+
+    private class ResultWorker(
+        appContext: AppContext,
+        private val result: TaskResult,
+    ) : Worker<ResumePayload>(appContext), CheckpointedWorker<ResumePayload> {
+
+        override suspend fun run(payload: ResumePayload, context: RuntimeContext): TaskResult {
+            error("Checkpointed workers must use the checkpoint-aware run method.")
+        }
+
+        override suspend fun run(
+            payload: ResumePayload,
+            context: RuntimeContext,
+            checkpoints: CheckpointStore,
+        ): TaskResult {
+            checkpoints.write(Progress(context.attemptCount), schemaVersion = 1)
+            return result
+        }
+    }
+
+    private fun registry(factory: (AppContext) -> Worker<ResumePayload>): WorkerRegistry {
+        val serializer = ResumePayload.serializer()
+        val registration = WorkerRegistration(
+            type = ResumePayload::class,
+            typeId = serializer.descriptor.serialName,
+            serializer = serializer,
+            factory = WorkerFactory(factory)
+        )
+        return WorkerRegistry(
+            registrations = mapOf(ResumePayload::class to registration),
+            json = json
+        )
+    }
+
+    private fun database(): MeeseeksDatabase {
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        MeeseeksDatabase.Schema.create(driver)
+        return MeeseeksDatabase(driver, taskLogEntityAdapter(json))
+    }
+
+    private fun insertTask(
+        database: MeeseeksDatabase,
+        registry: WorkerRegistry,
+        taskId: String,
+    ) {
+        val normalized = TaskMapper.normalizeRequest(
+            request = TaskRequest(
+                payload = ResumePayload(taskId),
+                retryPolicy = TaskRetryPolicy.FixedInterval(
+                    retryInterval = 1.seconds,
+                    maxRetries = 3,
+                ),
+            ),
+            currentTimeMs = 0L,
+            registry = registry,
+            config = BGTaskManagerConfig()
+        )
+
+        database.taskSpecQueries.insertTask(
+            id = taskId,
+            state = normalized.state,
+            created_at_ms = 0L,
+            updated_at_ms = 0L,
+            platform_id = null,
+            payload_type_id = normalized.payloadTypeId,
+            payload_data = normalized.payloadData,
+            priority = normalized.priority,
+            requires_network = normalized.requiresNetwork,
+            requires_charging = normalized.requiresCharging,
+            requires_battery_not_low = normalized.requiresBatteryNotLow,
+            next_run_time_ms = normalized.nextRunTimeMs,
+            schedule_type = normalized.scheduleType,
+            initial_delay_ms = normalized.initialDelayMs,
+            interval_duration_ms = normalized.intervalMs,
+            flex_duration_ms = normalized.flexMs,
+            backoff_policy = normalized.backoffPolicy,
+            backoff_delay_ms = normalized.backoffDelayMs,
+            max_retries = normalized.maxRetries,
+            backoff_multiplier = normalized.backoffMultiplier,
+            backoff_jitter_factor = normalized.backoffJitterFactor,
+        )
+    }
+
+    private fun checkpointStore(
+        database: MeeseeksDatabase,
+        registry: WorkerRegistry,
+        taskId: String,
+    ): RealCheckpointStore {
+        return RealCheckpointStore(
+            database = database,
+            registry = registry,
+            taskId = taskId,
+            payloadTypeId = payloadTypeId(),
+            workerTypeId = payloadTypeId(),
+        )
+    }
+
+    private fun checkpointCount(database: MeeseeksDatabase, taskId: String): Long {
+        return database.taskCheckpointQueries.countCheckpointsForTask(taskId).executeAsOne()
+    }
+
+    private fun payloadTypeId(): String {
+        return ResumePayload.serializer().descriptor.serialName
+    }
+
+    private fun manager(
+        database: MeeseeksDatabase,
+        registry: WorkerRegistry,
+        scheduler: Scheduler,
+    ): RealBGTaskManager {
+        val taskScheduler = TaskScheduler(scheduler)
+        val workRequestFactory = WorkRequestFactory()
+        val config = BGTaskManagerConfig(orphanedTaskWatchdogInterval = Duration.ZERO)
+        return RealBGTaskManager(
+            database = database,
+            workRequestFactory = workRequestFactory,
+            taskScheduler = taskScheduler,
+            taskRescheduler = NoOpTaskRescheduler,
+            config = config,
+            registry = registry,
+            constraintCapabilities = ConstraintCapabilities.JVM,
+            appContext = TestAppContext,
+        )
+    }
+
+    private fun createInMemoryScheduler(): Scheduler {
+        val properties = Properties().apply {
+            put("org.quartz.scheduler.instanceName", "meeseeks-checkpoint-test-${UUID.randomUUID()}")
+            put("org.quartz.scheduler.instanceId", "AUTO")
+            put("org.quartz.threadPool.class", "org.quartz.simpl.SimpleThreadPool")
+            put("org.quartz.threadPool.threadCount", "1")
+            put("org.quartz.jobStore.class", "org.quartz.simpl.RAMJobStore")
+        }
+
+        return StdSchedulerFactory(properties).scheduler.apply {
+            start()
+        }
+    }
+
+    private object NoOpTaskRescheduler : TaskRescheduler {
+        override fun rescheduleTasks() = Unit
+
+        override fun rescheduleTask(taskSpec: TaskSpec) = Unit
+    }
+}


### PR DESCRIPTION
## Summary
- Implements the checkpoint contract from #75: `CheckpointedWorker` (abstract class extending `Worker`) and `CheckpointStore` with reified helpers
- Persists typed checkpoint rows with SQLDelight (migration 4), payload-cipher reuse, overwrite, key clear, and clearAll support
- Wires `TaskExecutor` to invoke the checkpoint-aware `run` for checkpointed workers and retain checkpoints across retry/transient failure while clearing on success, permanent failure, and cancellation (cleanup rides the same guarded-cancel transaction as the durable `Cancelled` event)
- `RealCheckpointStore` dispatches database work to `MeeseeksDispatchers.IO` so the suspend API never blocks the worker's thread

## Design notes
- The class-based worker makes `TaskExecutor`'s cast sound (the interface allowed mismatched payload type parameters) and removes per-worker boilerplate.
- No `schemaVersion` column: it was never read back for validation; workers version their own serializable checkpoint class.
- No `task_id` index on `taskCheckpointEntity`: the composite primary key's left prefix already covers those lookups.

## Stack
- Base: #75 — the full chain is #73 → #74 → #75 → #76 → #77

## Verification
- `./gradlew preflight :runtime:jvmTest :runtime:jsTest :runtime:check`
- `./gradlew :runtime:jvmApiCheck :runtime:klibApiCheck :runtime:verifyCommonMainMeeseeksDatabaseMigration --warning-mode fail` (migration 4 verified against the committed schema snapshot)
- JVM integration coverage: retry resume, overwrite/clear, corrupt/incompatible reads, terminal cleanup, cancel cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)