### PR TITLE
MEESEEK-58: Add checkpoint kill-resume verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ missedEvents.forEach { event ->
 - JS guide: `docs/platforms/js.md`
 - Completion replay: `docs/completion-replay.md`
 - Worker checkpoint API contract: `docs/checkpoint-api-contract.md`
+- Worker checkpoint verification: `docs/checkpoint-verification.md`
 - Capability matrix: `docs/capabilities.md`
 - Troubleshooting: `docs/troubleshooting.md`
 - Migration notes: `docs/migration-0x-to-1x.md`

--- a/docs/checkpoint-api-contract.md
+++ b/docs/checkpoint-api-contract.md
@@ -4,6 +4,8 @@ This is the public contract for worker-controlled checkpoints. It defines app-le
 
 Meeseeks does not restore coroutine stacks, function locals, open sockets, file handles, transactions, or arbitrary in-memory objects. Workers must make side effects idempotent and explicitly write checkpoints at safe boundaries.
 
+Verification details and production guidance live in `docs/checkpoint-verification.md`.
+
 ## Public API shape
 
 `RuntimeContext` is a public data class in the 1.x API surface. Adding constructor properties would change generated `copy`/`componentN` members and is not 1.x-compatible. Checkpoint support should therefore be additive through a new worker base class and store type.
@@ -202,6 +204,6 @@ Avoid in 1.x:
 - Adding constructor parameters to `RuntimeContext`.
 - Adding abstract methods to `Worker` or `BGTaskManager`.
 - Changing `Worker.run(payload, context)` semantics for existing workers.
-- Exposing raw SQLDelight checkpoint rows as the public API.
+- Treating generated SQLDelight checkpoint rows as supported public API. App code should use `CheckpointStore`; generated `runtime.db` types remain outside the stable API packages listed in the README.
 
 If a future 2.0 release wants checkpoint access directly on `RuntimeContext`, it can redesign the context constructor and generated data-class members at a major-version boundary.

--- a/docs/checkpoint-verification.md
+++ b/docs/checkpoint-verification.md
@@ -2,7 +2,7 @@
 
 Meeseeks verifies checkpoint resume behavior with a repeatable JVM fixture in `CheckpointPersistenceJvmTest.multiStepWorkerSkipsCompletedStepsAfterManagerRestart`.
 
-The fixture models a checkpointed worker with three idempotent steps:
+The fixture models a worker extending `CheckpointedWorker` with three idempotent steps:
 
 1. `download`
 2. `transform`

--- a/docs/checkpoint-verification.md
+++ b/docs/checkpoint-verification.md
@@ -1,0 +1,56 @@
+# Checkpoint Kill-Resume Verification
+
+Meeseeks verifies checkpoint resume behavior with a repeatable JVM fixture in `CheckpointPersistenceJvmTest.multiStepWorkerSkipsCompletedStepsAfterManagerRestart`.
+
+The fixture models a checkpointed worker with three idempotent steps:
+
+1. `download`
+2. `transform`
+3. `upload`
+
+On the first execution, the worker completes `download` and `transform`, writes a checkpoint after each completed step, then returns a transient failure to model process or manager death after durable progress was saved. The second execution builds a new worker registry and worker instance against the same Meeseeks database. The restarted worker reads the checkpoint and runs only `upload`.
+
+The assertion is intentionally about side effects, not just stored rows: `download`, `transform`, and `upload` each appear exactly once. Completed steps are not repeated after restart/resume, and the checkpoint row is cleared after final success.
+
+Run the proof with:
+
+```bash
+./gradlew :runtime:jvmTest --stacktrace
+```
+
+The same gate also covers checkpoint overwrite, key clearing, corrupt payload errors, incompatible payload errors, retry retention, permanent failure cleanup, and cancellation cleanup.
+
+## Platform Limits
+
+This proof is platform-independent at the runtime contract level: it exercises Meeseeks persistence, worker recreation, checkpoint read/write, retry retention, and terminal cleanup without relying on a specific OS scheduler.
+
+It does not claim exact process-kill scheduling guarantees for every target:
+
+- Android execution still depends on WorkManager delivery and OS constraints.
+- iOS background execution remains best effort and depends on the system granting runtime.
+- JS execution depends on the available database driver and browser/runtime lifecycle.
+- JVM execution is the strongest automated proof because the test can synchronously run the shared `TaskExecutor` against the persistent database.
+
+## Worker Guidance
+
+Place checkpoints after an idempotent step has finished and its side effect is safe to skip on a later retry. Do not checkpoint before starting a side effect; a crash after the checkpoint but before the side effect would incorrectly skip work.
+
+Recommended pattern:
+
+```kotlin
+val checkpoint = checkpoints.read<SyncCheckpoint>() ?: SyncCheckpoint()
+
+if (!checkpoint.downloaded) {
+    downloadBatch()
+    checkpoints.write(checkpoint.copy(downloaded = true))
+}
+
+if (!checkpoint.transformed) {
+    transformBatch()
+    checkpoints.write(checkpoint.copy(transformed = true))
+}
+
+uploadBatch()
+```
+
+Workers should treat checkpoint data as app-owned schema. If `CheckpointDecodeException` or `CheckpointIncompatibleException` is safe to recover from, clear the checkpoint and restart from step zero. If replaying a step would duplicate external side effects, fail explicitly and let the app repair or migrate the stored checkpoint state.

--- a/runtime/src/jvmTest/kotlin/dev/mattramotar/meeseeks/runtime/internal/CheckpointPersistenceJvmTest.kt
+++ b/runtime/src/jvmTest/kotlin/dev/mattramotar/meeseeks/runtime/internal/CheckpointPersistenceJvmTest.kt
@@ -49,6 +49,9 @@ class CheckpointPersistenceJvmTest {
     private data class Progress(val completedStep: Int)
 
     @Serializable
+    private data class MultiStepCheckpoint(val completedThrough: Int = 0)
+
+    @Serializable
     private data class OtherProgress(val value: String)
 
     private val json = Json {
@@ -87,6 +90,56 @@ class CheckpointPersistenceJvmTest {
 
         assertEquals(TaskExecutor.ExecutionResult.Terminal.Success, secondResult)
         assertEquals(listOf(null, Progress(1)), observed)
+        assertEquals(0L, checkpointCount(database, taskId))
+    }
+
+    @Test
+    fun multiStepWorkerSkipsCompletedStepsAfterManagerRestart() = runTest {
+        val database = database()
+        val sideEffects = mutableListOf<String>()
+        val taskId = "multi-step-resume-task"
+        val firstRegistry = registry { appContext ->
+            MultiStepWorker(
+                appContext = appContext,
+                sideEffects = sideEffects,
+                failAfterCompletedThrough = 2,
+            )
+        }
+
+        insertTask(database, firstRegistry, taskId)
+
+        val firstResult = TaskExecutor.execute(
+            taskId = taskId,
+            database = database,
+            registry = firstRegistry,
+            appContext = TestAppContext,
+            config = BGTaskManagerConfig()
+        )
+
+        assertIs<TaskExecutor.ExecutionResult.ScheduleNextActivation>(firstResult)
+        assertEquals(listOf("download", "transform"), sideEffects)
+        assertEquals(1L, checkpointCount(database, taskId))
+
+        val restartedRegistry = registry { appContext ->
+            MultiStepWorker(
+                appContext = appContext,
+                sideEffects = sideEffects,
+                failAfterCompletedThrough = null,
+            )
+        }
+        val secondResult = TaskExecutor.execute(
+            taskId = taskId,
+            database = database,
+            registry = restartedRegistry,
+            appContext = TestAppContext,
+            config = BGTaskManagerConfig()
+        )
+
+        assertEquals(TaskExecutor.ExecutionResult.Terminal.Success, secondResult)
+        assertEquals(listOf("download", "transform", "upload"), sideEffects)
+        assertEquals(1, sideEffects.count { it == "download" })
+        assertEquals(1, sideEffects.count { it == "transform" })
+        assertEquals(1, sideEffects.count { it == "upload" })
         assertEquals(0L, checkpointCount(database, taskId))
     }
 
@@ -222,6 +275,39 @@ class CheckpointPersistenceJvmTest {
             } else {
                 TaskResult.Success
             }
+        }
+    }
+
+    private class MultiStepWorker(
+        appContext: AppContext,
+        private val sideEffects: MutableList<String>,
+        private val failAfterCompletedThrough: Int?,
+    ) : Worker<ResumePayload>(appContext), CheckpointedWorker<ResumePayload> {
+
+        private val steps = listOf("download", "transform", "upload")
+
+        override suspend fun run(payload: ResumePayload, context: RuntimeContext): TaskResult {
+            error("Checkpointed workers must use the checkpoint-aware run method.")
+        }
+
+        override suspend fun run(
+            payload: ResumePayload,
+            context: RuntimeContext,
+            checkpoints: CheckpointStore,
+        ): TaskResult {
+            val checkpoint = checkpoints.read<MultiStepCheckpoint>() ?: MultiStepCheckpoint()
+
+            for (index in checkpoint.completedThrough until steps.size) {
+                sideEffects += steps[index]
+                val completedThrough = index + 1
+                checkpoints.write(MultiStepCheckpoint(completedThrough = completedThrough))
+
+                if (completedThrough == failAfterCompletedThrough) {
+                    return TaskResult.Failure.Transient(RuntimeException("simulated process death"))
+                }
+            }
+
+            return TaskResult.Success
         }
     }
 

--- a/runtime/src/jvmTest/kotlin/dev/mattramotar/meeseeks/runtime/internal/CheckpointPersistenceJvmTest.kt
+++ b/runtime/src/jvmTest/kotlin/dev/mattramotar/meeseeks/runtime/internal/CheckpointPersistenceJvmTest.kt
@@ -282,13 +282,9 @@ class CheckpointPersistenceJvmTest {
         appContext: AppContext,
         private val sideEffects: MutableList<String>,
         private val failAfterCompletedThrough: Int?,
-    ) : Worker<ResumePayload>(appContext), CheckpointedWorker<ResumePayload> {
+    ) : CheckpointedWorker<ResumePayload>(appContext) {
 
         private val steps = listOf("download", "transform", "upload")
-
-        override suspend fun run(payload: ResumePayload, context: RuntimeContext): TaskResult {
-            error("Checkpointed workers must use the checkpoint-aware run method.")
-        }
 
         override suspend fun run(
             payload: ResumePayload,


### PR DESCRIPTION
## Summary
- Adds a multi-step checkpointed worker proof that a restarted worker skips completed steps and runs only remaining work
- Documents the kill/resume verification model, platform-specific limits, and idempotent checkpoint placement guidance
- Links checkpoint verification from the checkpoint contract and README

## Stack
- Base: #76 — the full chain is #73 → #74 → #75 → #76 → #77
- The fixture extends the class-based `CheckpointedWorker` from the redesigned contract

## Verification
- `./gradlew preflight :runtime:jvmTest :runtime:jsTest`
- `./gradlew :runtime:jvmApiCheck :runtime:klibApiCheck :runtime:verifyCommonMainMeeseeksDatabaseMigration --warning-mode fail`

🤖 Generated with [Claude Code](https://claude.com/claude-code)